### PR TITLE
CPU-time based profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +144,8 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 name = "pf2"
 version = "0.1.0"
 dependencies = [
+ "cc",
+ "libc",
  "rb-sys",
  "serde",
  "serde_derive",

--- a/ext/pf2/Cargo.toml
+++ b/ext/pf2/Cargo.toml
@@ -9,7 +9,11 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
+libc = "0.2.149"
 rb-sys = { version = "0.9.82", features = ["stable-api", "stable-api-compiled-testing"] } # using stable-api-compiled-testing for generating bindings from Ruby source
 serde = "1.0.189"
 serde_derive = "1.0.189"
 serde_json = "1.0.107"
+
+[build-dependencies]
+cc = "1.0.83"

--- a/ext/pf2/build.rs
+++ b/ext/pf2/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cc::Build::new().file("src/siginfo_t.c").compile("ccode");
+}

--- a/ext/pf2/src/lib.rs
+++ b/ext/pf2/src/lib.rs
@@ -6,4 +6,5 @@ mod ruby_init;
 
 mod profile;
 mod sample_collector;
+mod timer_collector;
 mod util;

--- a/ext/pf2/src/ruby_init.rs
+++ b/ext/pf2/src/ruby_init.rs
@@ -3,6 +3,7 @@
 use rb_sys::*;
 
 use crate::sample_collector::SampleCollector;
+use crate::timer_collector::TimerCollector;
 use crate::util::*;
 
 #[allow(non_snake_case)]
@@ -27,6 +28,28 @@ extern "C" fn Init_pf2() {
             rb_mPf2_Collector_PostponedJobCollector,
             cstr!("stop"),
             Some(to_ruby_cfunc1(SampleCollector::rb_stop)),
+            0,
+        );
+
+        let rb_mPf2_TimerCollector =
+            rb_define_class_under(rb_mPf2, cstr!("TimerCollector"), rb_cObject);
+        rb_define_alloc_func(rb_mPf2_TimerCollector, Some(TimerCollector::rb_alloc));
+        rb_define_method(
+            rb_mPf2_TimerCollector,
+            cstr!("start"),
+            Some(to_ruby_cfunc2(TimerCollector::rb_start)),
+            1,
+        );
+        rb_define_method(
+            rb_mPf2_TimerCollector,
+            cstr!("stop"),
+            Some(to_ruby_cfunc1(TimerCollector::rb_stop)),
+            0,
+        );
+        rb_define_method(
+            rb_mPf2_TimerCollector,
+            cstr!("install_to_current_thread"),
+            Some(to_ruby_cfunc1(TimerCollector::rb_install_to_current_thread)),
             0,
         );
     }

--- a/ext/pf2/src/siginfo_t.c
+++ b/ext/pf2/src/siginfo_t.c
@@ -1,0 +1,5 @@
+#include <signal.h>
+
+void *extract_si_value_sival_ptr(siginfo_t *siginfo) {
+  return siginfo->si_value.sival_ptr;
+}

--- a/ext/pf2/src/timer_collector.rs
+++ b/ext/pf2/src/timer_collector.rs
@@ -1,0 +1,314 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::ffi::{c_int, c_void, CString};
+use std::mem;
+use std::ptr::null_mut;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use rb_sys::*;
+
+use crate::profile::Profile;
+use crate::sample_collector::Sample;
+use crate::util::*;
+
+unsafe extern "C" fn dmark(ptr: *mut c_void) {
+    unsafe {
+        let collector: Box<TimerCollector> = Box::from_raw(ptr as *mut TimerCollector);
+
+        // Mark collected sample VALUEs
+        {
+            let samples = collector.samples.try_read().unwrap();
+            for sample in samples.iter() {
+                rb_gc_mark(sample.ruby_thread);
+                for frame in sample.frames.iter() {
+                    rb_gc_mark(*frame);
+                }
+            }
+        }
+
+        mem::forget(collector);
+    }
+}
+unsafe extern "C" fn dfree(ptr: *mut c_void) {
+    unsafe {
+        let collector: Box<TimerCollector> = Box::from_raw(ptr as *mut TimerCollector);
+        drop(collector);
+    }
+}
+unsafe extern "C" fn dsize(_: *const c_void) -> size_t {
+    // FIXME: Report something better
+    mem::size_of::<TimerCollector>() as size_t
+}
+
+static mut RBDATA: rb_data_type_t = rb_data_type_t {
+    wrap_struct_name: cstr!("TimerCollectorInternal"),
+    function: rb_data_type_struct__bindgen_ty_1 {
+        dmark: Some(dmark),
+        dfree: Some(dfree),
+        dsize: Some(dsize),
+        dcompact: None,
+        reserved: [null_mut(); 1],
+    },
+    parent: null_mut(),
+    data: null_mut(),
+    flags: 0,
+};
+
+#[derive(Clone, Debug)]
+pub struct TimerCollector {
+    start_time: Instant,
+    ruby_threads: Arc<RwLock<Vec<VALUE>>>,
+    samples: Arc<RwLock<Vec<Sample>>>,
+    stop_requested: Arc<AtomicBool>,
+    signal_handler_thread_tid: Arc<AtomicI64>,
+}
+
+#[derive(Debug)]
+struct CollectorThreadData {
+    start_time: Instant,
+    ruby_thread: VALUE,
+    samples: Arc<RwLock<Vec<Sample>>>,
+}
+
+impl TimerCollector {
+    fn new() -> Self {
+        TimerCollector {
+            start_time: Instant::now(),
+            ruby_threads: Arc::new(RwLock::new(vec![])),
+            samples: Arc::new(RwLock::new(vec![])),
+            stop_requested: Arc::new(AtomicBool::new(false)),
+            signal_handler_thread_tid: Arc::new(AtomicI64::new(0)), // TODO: Option
+        }
+    }
+
+    fn start(&mut self, _rbself: VALUE, ruby_threads: VALUE) -> VALUE {
+        // Register threads
+        {
+            let stored_threads = &mut self.ruby_threads.try_write().unwrap();
+            unsafe {
+                for i in 0..RARRAY_LEN(ruby_threads) {
+                    stored_threads.push(rb_ary_entry(ruby_threads, i));
+                }
+            }
+        }
+
+        self.create_signal_handler_thread();
+        thread::sleep(Duration::from_millis(10));
+
+        Qtrue.into()
+    }
+
+    fn stop(&self, _rbself: VALUE) -> VALUE {
+        // Stop the collector thread
+        self.stop_requested.store(true, Ordering::Relaxed);
+        let profile = Profile::from_samples(&self.samples.try_read().unwrap());
+
+        let json = serde_json::to_string(&profile).unwrap();
+        let json_cstring = CString::new(json).unwrap();
+        unsafe { rb_str_new_cstr(json_cstring.as_ptr()) }
+    }
+
+    fn install_to_current_thread(&self, _rbself: VALUE) -> VALUE {
+        let ruby_thread: VALUE = unsafe { rb_thread_current() };
+        let data_for_job: Arc<CollectorThreadData> = Arc::new(CollectorThreadData {
+            start_time: self.start_time,
+            ruby_thread,
+            samples: Arc::clone(&self.samples),
+        });
+
+        // Wanted to use SIGEV_THREAD, but it's not exposed through the libc crate
+        let mut timer_id: mem::MaybeUninit<libc::timer_t> = mem::MaybeUninit::uninit();
+        let mut sigevent: libc::sigevent = unsafe { mem::zeroed() };
+        sigevent.sigev_notify = libc::SIGEV_THREAD_ID;
+        sigevent.sigev_signo = libc::SIGALRM;
+        sigevent.sigev_value.sival_ptr = Arc::into_raw(Arc::clone(&data_for_job)) as *mut c_void;
+        sigevent.sigev_notify_thread_id = self
+            .signal_handler_thread_tid
+            .load(Ordering::Relaxed)
+            .try_into()
+            .unwrap();
+        unsafe {
+            let err = libc::timer_create(
+                libc::CLOCK_THREAD_CPUTIME_ID,
+                &mut sigevent,
+                timer_id.as_mut_ptr(),
+            );
+            if err != 0 {
+                panic!("timer_create failed: {}", err);
+            }
+        }
+
+        // Configure timer to fire every 50 ms of CPU time
+        let mut its: libc::itimerspec = unsafe { mem::zeroed() };
+        its.it_interval.tv_sec = 0;
+        its.it_interval.tv_nsec = 10_000_000; // 50 ms
+        its.it_value.tv_sec = 0;
+        its.it_value.tv_nsec = 10_000_000;
+        unsafe {
+            let err = libc::timer_settime(*timer_id.as_ptr(), 0, &its, null_mut());
+            if err != 0 {
+                panic!("timer_settime failed: {}", err);
+            }
+        }
+
+        unsafe {
+            println!("Installed to tid={}", libc::syscall(libc::SYS_gettid));
+        }
+        Qtrue.into()
+    }
+
+    fn create_signal_handler_thread(&self) {
+        let tid = Arc::clone(&self.signal_handler_thread_tid);
+        thread::spawn(move || {
+            tid.store(
+                unsafe { libc::syscall(libc::SYS_gettid) },
+                Ordering::Relaxed,
+            );
+
+            // Install sigaction to this thread
+            let mut sigaction: libc::sigaction = unsafe { mem::zeroed() };
+            sigaction.sa_sigaction = Self::signal_handler as usize;
+            sigaction.sa_flags = libc::SA_SIGINFO;
+            unsafe {
+                let err = libc::sigaction(libc::SIGALRM, &sigaction, null_mut());
+                if err != 0 {
+                    panic!("sigaction failed: {}", err);
+                }
+            }
+
+            loop {
+                // do nothing; wait for signal
+                thread::sleep(Duration::from_millis(1));
+            }
+        });
+    }
+
+    extern "C" fn signal_handler(_sig: c_int, info: *mut c_void, _ucontext: *mut c_void) {
+        // println!("signal!");
+        let ptr = unsafe { extract_si_value_sival_ptr(info) as *mut CollectorThreadData };
+        let data = unsafe { Arc::from_raw(ptr) };
+
+        unsafe {
+            rb_postponed_job_register_one(
+                0,
+                Some(Self::postponed_job),
+                Arc::into_raw(data) as *mut c_void,
+            );
+        }
+    }
+
+    unsafe extern "C" fn postponed_job(data: *mut c_void) {
+        let data = unsafe { Arc::from_raw(data as *mut CollectorThreadData) };
+
+        // Collect stack information from specified Ruby Threads
+        let mut samples_to_push: Vec<Sample> = vec![];
+        if unsafe { rb_funcall(data.ruby_thread, rb_intern(cstr!("status")), 0) } == Qfalse as u64 {
+            return;
+        }
+
+        let mut buffer: [VALUE; 2000] = [0; 2000];
+        let mut linebuffer: [i32; 2000] = [0; 2000];
+        let lines: c_int = unsafe {
+            rb_profile_thread_frames(
+                data.ruby_thread,
+                0,
+                2000,
+                buffer.as_mut_ptr(),
+                linebuffer.as_mut_ptr(),
+            )
+        };
+
+        // FIXME: Will this really occur?
+        if lines == 0 {
+            return;
+        }
+
+        let mut sample = Sample {
+            elapsed_ns: Instant::now().duration_since(data.start_time).as_nanos(),
+            ruby_thread: data.ruby_thread,
+            ruby_thread_native_thread_id: unsafe {
+                rb_num2int(rb_funcall(
+                    data.ruby_thread,
+                    rb_intern(cstr!("native_thread_id")),
+                    0,
+                ))
+            },
+            frames: vec![],
+        };
+        for i in 0..lines {
+            let frame: VALUE = buffer[i as usize];
+            sample.frames.push(frame);
+        }
+        samples_to_push.push(sample);
+
+        // Try to lock samples; if failed, just skip this sample
+        // (dmark (GC) might be locking data.samples)
+        if let Ok(mut samples) = data.samples.try_write() {
+            samples.append(&mut samples_to_push);
+        } else {
+            println!("Failed to record samples (could not acquire lock on samples)")
+        };
+
+        mem::forget(data); // FIXME: something's leaking
+    }
+
+    // ----------
+
+    // Obtain the Ruby VALUE of `Pf2::TimerCollector`.
+    #[allow(non_snake_case)]
+    fn get_ruby_class() -> VALUE {
+        unsafe {
+            let rb_mPf2: VALUE = rb_define_module(cstr!("Pf2"));
+            rb_define_class_under(rb_mPf2, cstr!("TimerCollector"), rb_cObject)
+        }
+    }
+
+    fn get_struct_from(obj: VALUE) -> Box<Self> {
+        unsafe { Box::from_raw(rb_check_typeddata(obj, &RBDATA) as *mut TimerCollector) }
+    }
+
+    fn wrap_struct(collector: TimerCollector) -> VALUE {
+        #[allow(non_snake_case)]
+        let rb_cTimerCollector = Self::get_ruby_class();
+
+        unsafe {
+            rb_data_typed_object_wrap(
+                rb_cTimerCollector,
+                Box::into_raw(Box::new(collector)) as *mut _ as *mut c_void,
+                &RBDATA,
+            )
+        }
+    }
+
+    pub unsafe extern "C" fn rb_alloc(_rbself: VALUE) -> VALUE {
+        let collector = TimerCollector::new();
+        Self::wrap_struct(collector)
+    }
+
+    // TimerCollector.start
+    pub unsafe extern "C" fn rb_start(rbself: VALUE, ruby_threads: VALUE) -> VALUE {
+        let mut collector = Self::get_struct_from(rbself);
+        let ret = collector.start(rbself, ruby_threads);
+        mem::forget(collector);
+        ret
+    }
+
+    // TimerCollector.stop
+    pub unsafe extern "C" fn rb_stop(rbself: VALUE) -> VALUE {
+        let collector = Self::get_struct_from(rbself);
+        let ret = collector.stop(rbself);
+        mem::forget(collector);
+        ret
+    }
+
+    // TimerCollector.install_to_current_thread
+    pub unsafe extern "C" fn rb_install_to_current_thread(rbself: VALUE) -> VALUE {
+        let collector = Self::get_struct_from(rbself);
+        let ret = collector.install_to_current_thread(rbself);
+        mem::forget(collector);
+        ret
+    }
+}

--- a/ext/pf2/src/util.rs
+++ b/ext/pf2/src/util.rs
@@ -1,5 +1,6 @@
 use core::mem::transmute;
 use rb_sys::*;
+use std::ffi::c_void;
 
 // Convert str literal to C string literal
 macro_rules! cstr {
@@ -18,4 +19,8 @@ pub fn to_ruby_cfunc1<T>(f: unsafe extern "C" fn(T) -> VALUE) -> RubyCFunc {
 // TODO: rewrite as macro
 pub fn to_ruby_cfunc2<T, U>(f: unsafe extern "C" fn(T, U) -> VALUE) -> RubyCFunc {
     unsafe { transmute::<unsafe extern "C" fn(T, U) -> VALUE, RubyCFunc>(f) }
+}
+
+extern "C" {
+    pub fn extract_si_value_sival_ptr(info: *mut c_void) -> *mut c_void;
 }


### PR DESCRIPTION
Support per-process CPU-time based profiling by passing `CLOCK_THREAD_CPUTIME_ID` to `timer_create(2)`.
In this mode, samples should be collected each time when a pthread (= Ruby Thread) consumes a certain amount of CPU time.