### PR TITLE
Rename SampleCollector to TimerThreadScheduler & refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Signals are directed to Ruby Threads' underlying pthread, effectively "pausing" 
 
 This scheduler heavily relies on Ruby's 1:N Thread model (1 Ruby Threads is strongly tied to a native pthread). It will not work properly in MaNy (`RUBY_MN_THREADS=1`).
 
-#### TimerThreadScheduler (to be renamed from SampleCollector)
+#### TimerThreadScheduler
 
 Another scheduler is the `TimerThreadScheduler`, which maintains a time-keeping thread by itself. A new native thread (pthread on Linux/macOS) will be created, and an infinite loop will be run inside. After `sleep(2)`-ing for the specified interval time, sampling will be queued using Ruby's Postponed Job API.
 

--- a/ext/pf2/src/lib.rs
+++ b/ext/pf2/src/lib.rs
@@ -8,6 +8,6 @@ mod profile;
 mod profile_serializer;
 mod ringbuffer;
 mod sample;
-mod sample_collector;
 mod signal_scheduler;
+mod timer_thread_scheduler;
 mod util;

--- a/ext/pf2/src/ruby_init.rs
+++ b/ext/pf2/src/ruby_init.rs
@@ -2,8 +2,8 @@
 
 use rb_sys::*;
 
-use crate::sample_collector::SampleCollector;
 use crate::signal_scheduler::SignalScheduler;
+use crate::timer_thread_scheduler::TimerThreadScheduler;
 use crate::util::*;
 
 #[allow(non_snake_case)]
@@ -28,22 +28,22 @@ extern "C" fn Init_pf2() {
             0,
         );
 
-        let rb_mPf2_Collector_PostponedJobCollector =
-            rb_define_class_under(rb_mPf2, cstr!("SampleCollector"), rb_cObject);
+        let rb_mPf2_TimerThreadScheduler =
+            rb_define_class_under(rb_mPf2, cstr!("TimerThreadScheduler"), rb_cObject);
         rb_define_alloc_func(
-            rb_mPf2_Collector_PostponedJobCollector,
-            Some(SampleCollector::rb_alloc),
+            rb_mPf2_TimerThreadScheduler,
+            Some(TimerThreadScheduler::rb_alloc),
         );
         rb_define_method(
-            rb_mPf2_Collector_PostponedJobCollector,
+            rb_mPf2_TimerThreadScheduler,
             cstr!("start"),
-            Some(to_ruby_cfunc2(SampleCollector::rb_start)),
+            Some(to_ruby_cfunc2(TimerThreadScheduler::rb_start)),
             1,
         );
         rb_define_method(
-            rb_mPf2_Collector_PostponedJobCollector,
+            rb_mPf2_TimerThreadScheduler,
             cstr!("stop"),
-            Some(to_ruby_cfunc1(SampleCollector::rb_stop)),
+            Some(to_ruby_cfunc1(TimerThreadScheduler::rb_stop)),
             0,
         );
     }

--- a/ext/pf2/src/sample_collector.rs
+++ b/ext/pf2/src/sample_collector.rs
@@ -129,6 +129,8 @@ impl SampleCollector {
             unsafe {
                 // FIXME: data_for_job has a high chance of leaking memory here,
                 // as rb_postponed_job_register_one does not invoke postponed_job().
+                // FIXME: Migrate to the new Postponed Job API
+                #[allow(deprecated)]
                 rb_postponed_job_register_one(
                     0,
                     Some(Self::postponed_job),


### PR DESCRIPTION
This pull request rewrites TimerThreadScheduler. Many internal procedures and structs (namely Profile and Sample) are now shared with SignalScheduler.

