### PR TITLE
Compile SignalCollector only on Linux (macOS support)

### DIFF
--- a/ext/pf2/src/lib.rs
+++ b/ext/pf2/src/lib.rs
@@ -8,6 +8,7 @@ mod profile;
 mod profile_serializer;
 mod ringbuffer;
 mod sample;
+#[cfg(target_os = "linux")]
 mod signal_scheduler;
 mod timer_thread_scheduler;
 mod util;

--- a/ext/pf2/src/ruby_init.rs
+++ b/ext/pf2/src/ruby_init.rs
@@ -12,21 +12,24 @@ extern "C" fn Init_pf2() {
     unsafe {
         let rb_mPf2: VALUE = rb_define_module(cstr!("Pf2"));
 
-        let rb_mPf2_SignalCollector =
-            rb_define_class_under(rb_mPf2, cstr!("SignalCollector"), rb_cObject);
-        rb_define_alloc_func(rb_mPf2_SignalCollector, Some(SignalScheduler::rb_alloc));
-        rb_define_method(
-            rb_mPf2_SignalCollector,
-            cstr!("start"),
-            Some(to_ruby_cfunc2(SignalScheduler::rb_start)),
-            1,
-        );
-        rb_define_method(
-            rb_mPf2_SignalCollector,
-            cstr!("stop"),
-            Some(to_ruby_cfunc1(SignalScheduler::rb_stop)),
-            0,
-        );
+        #[cfg(target_os = "linux")]
+        {
+            let rb_mPf2_SignalCollector =
+                rb_define_class_under(rb_mPf2, cstr!("SignalCollector"), rb_cObject);
+            rb_define_alloc_func(rb_mPf2_SignalCollector, Some(SignalScheduler::rb_alloc));
+            rb_define_method(
+                rb_mPf2_SignalCollector,
+                cstr!("start"),
+                Some(to_ruby_cfunc2(SignalScheduler::rb_start)),
+                1,
+            );
+            rb_define_method(
+                rb_mPf2_SignalCollector,
+                cstr!("stop"),
+                Some(to_ruby_cfunc1(SignalScheduler::rb_stop)),
+                0,
+            );
+        }
 
         let rb_mPf2_TimerThreadScheduler =
             rb_define_class_under(rb_mPf2, cstr!("TimerThreadScheduler"), rb_cObject);


### PR DESCRIPTION
SignalCollector relies on Linux-only features such as SIGEV_THREAD_ID, and will not compile outside of Linux. This patch limits compilation of SignalCollector only to Linux, allowing Pf2 usage on macOS and other *NIX environments.