### PR TITLE
Accept configuration through initializer kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ Usage
 Pf2 will collect samples every 10 ms of wall time by default.
 
 ```ruby
-# Specify Ruby Threads to track in the first argument.
-# New Ruby Threads will be tracked if the second argument is true.
-Pf2.start([Thread.current], false)
-your_code_here() # will be profiled
-Thread.new { threaded_code() } # will also be profiled if second argument is true
+# Threads in `threads` will be tracked
+Pf2.start(threads: [Thread.current])
+
+your_code_here
 
 # Stop profiling and save the profile for visualization
 profile = Pf2.stop

--- a/ext/pf2/src/ruby_init.rs
+++ b/ext/pf2/src/ruby_init.rs
@@ -29,13 +29,13 @@ extern "C" fn Init_pf2() {
             rb_define_method(
                 rb_mPf2_SignalScheduler,
                 cstr!("start"),
-                Some(to_ruby_cfunc3(SignalScheduler::rb_start)),
-                2,
+                Some(to_ruby_cfunc_with_args(SignalScheduler::rb_start)),
+                -1,
             );
             rb_define_method(
                 rb_mPf2_SignalScheduler,
                 cstr!("stop"),
-                Some(to_ruby_cfunc1(SignalScheduler::rb_stop)),
+                Some(to_ruby_cfunc_with_no_args(SignalScheduler::rb_stop)),
                 0,
             );
         }
@@ -49,13 +49,13 @@ extern "C" fn Init_pf2() {
         rb_define_method(
             rb_mPf2_TimerThreadScheduler,
             cstr!("start"),
-            Some(to_ruby_cfunc3(TimerThreadScheduler::rb_start)),
-            2,
+            Some(to_ruby_cfunc_with_args(TimerThreadScheduler::rb_start)),
+            -1,
         );
         rb_define_method(
             rb_mPf2_TimerThreadScheduler,
             cstr!("stop"),
-            Some(to_ruby_cfunc1(TimerThreadScheduler::rb_stop)),
+            Some(to_ruby_cfunc_with_no_args(TimerThreadScheduler::rb_stop)),
             0,
         );
     }

--- a/ext/pf2/src/ruby_init.rs
+++ b/ext/pf2/src/ruby_init.rs
@@ -28,9 +28,15 @@ extern "C" fn Init_pf2() {
             rb_define_alloc_func(rb_mPf2_SignalScheduler, Some(SignalScheduler::rb_alloc));
             rb_define_method(
                 rb_mPf2_SignalScheduler,
-                cstr!("start"),
-                Some(to_ruby_cfunc_with_args(SignalScheduler::rb_start)),
+                cstr!("initialize"),
+                Some(to_ruby_cfunc_with_args(SignalScheduler::rb_initialize)),
                 -1,
+            );
+            rb_define_method(
+                rb_mPf2_SignalScheduler,
+                cstr!("start"),
+                Some(to_ruby_cfunc_with_no_args(SignalScheduler::rb_start)),
+                0,
             );
             rb_define_method(
                 rb_mPf2_SignalScheduler,

--- a/ext/pf2/src/ruby_init.rs
+++ b/ext/pf2/src/ruby_init.rs
@@ -54,9 +54,15 @@ extern "C" fn Init_pf2() {
         );
         rb_define_method(
             rb_mPf2_TimerThreadScheduler,
-            cstr!("start"),
-            Some(to_ruby_cfunc_with_args(TimerThreadScheduler::rb_start)),
+            cstr!("initialize"),
+            Some(to_ruby_cfunc_with_args(TimerThreadScheduler::rb_initialize)),
             -1,
+        );
+        rb_define_method(
+            rb_mPf2_TimerThreadScheduler,
+            cstr!("start"),
+            Some(to_ruby_cfunc_with_no_args(TimerThreadScheduler::rb_start)),
+            0,
         );
         rb_define_method(
             rb_mPf2_TimerThreadScheduler,

--- a/ext/pf2/src/signal_scheduler/configuration.rs
+++ b/ext/pf2/src/signal_scheduler/configuration.rs
@@ -1,8 +1,12 @@
-use std::str::FromStr;
+use std::{collections::HashSet, str::FromStr};
+
+use rb_sys::VALUE;
 
 #[derive(Clone, Debug)]
 pub struct Configuration {
     pub time_mode: TimeMode,
+    pub target_ruby_threads: HashSet<VALUE>,
+    pub track_new_threads: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/ext/pf2/src/util.rs
+++ b/ext/pf2/src/util.rs
@@ -13,10 +13,10 @@ pub(crate) use cstr;
 pub type RubyCFunc = unsafe extern "C" fn() -> VALUE;
 
 // TODO: rewrite as macro
-pub fn to_ruby_cfunc1<T>(f: unsafe extern "C" fn(T) -> VALUE) -> RubyCFunc {
+pub fn to_ruby_cfunc_with_no_args<T>(f: unsafe extern "C" fn(T) -> VALUE) -> RubyCFunc {
     unsafe { transmute::<unsafe extern "C" fn(T) -> VALUE, RubyCFunc>(f) }
 }
-pub fn to_ruby_cfunc3<T, U, V>(f: unsafe extern "C" fn(T, U, V) -> VALUE) -> RubyCFunc {
+pub fn to_ruby_cfunc_with_args<T, U, V>(f: unsafe extern "C" fn(T, U, V) -> VALUE) -> RubyCFunc {
     unsafe { transmute::<unsafe extern "C" fn(T, U, V) -> VALUE, RubyCFunc>(f) }
 }
 


### PR DESCRIPTION
Configuration is now accepted in the following manner:

```rb
profiler = Pf2::TimerThreadScheduler.new(threads: [Thread.current], track_new_threads: true)
```

...instead of `Pf2::TimerThreadScheduler.new.start([Thread.current], true)` .