### PR TITLE
Implement pf2 serve subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Added
+
+- `pf2 serve` subcommand
+  - `pf2 serve -- ruby target.rb`
+  - Profile programs without any change
+
 
 ## [0.4.0] - 2024-03-22
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     pf2 (0.4.0)
       rake-compiler
       rb_sys (~> 0.9.63)
+      webrick
 
 GEM
   remote: https://rubygems.org/
@@ -13,6 +14,7 @@ GEM
     rake-compiler (1.2.5)
       rake
     rb_sys (0.9.82)
+    webrick (1.8.1)
 
 PLATFORMS
   x86_64-linux

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ Notable Capabilites
 Usage
 --------
 
+### Quickstart
+
+Run your Ruby program through `pf2 serve`.
+Wait a while until Pf2 collects profiles (or until the target program exits), then open the displayed link for visualization.
+
+```
+$ pf2 serve -- ruby target.rb
+[Pf2] Listening on localhost:51502.
+[Pf2] Open https://profiler.firefox.com/from-url/http%3A%2F%2Flocalhost%3A51502%2Fprofile for visualization.
+
+I'm the target program!
+```
+
 ### Profiling
 
 Pf2 will collect samples every 10 ms of wall time by default.

--- a/lib/pf2/cli.rb
+++ b/lib/pf2/cli.rb
@@ -10,17 +10,43 @@ module Pf2
     end
 
     def run(argv)
+      argv = argv.dup
+      program_name = File.basename($PROGRAM_NAME)
+
+      subcommand = argv.shift
+      case subcommand
+      when 'report'
+        subcommand_report(argv)
+      when 'serve'
+        subcommand_serve(argv)
+      when 'version'
+        puts VERSION
+        return 0
+      when '--help'
+        STDERR.puts <<~__EOS__
+        Usage: #{program_name} COMMAND [options]
+
+        Commands:
+          report    Generate a report from a profile
+          serve     Start an HTTP server alongside a target process
+          version   Show version information
+        __EOS__
+
+        return 1
+      else
+        STDERR.puts "#{program_name}: Unknown subcommand #{subcommand}"
+        return 1
+      end
+    end
+
+    def subcommand_report(argv)
       options = {}
       option_parser = OptionParser.new do |opts|
-        opts.on('-v', '--version', 'Prints version') do
-          puts Pf2::VERSION
-          exit
-        end
-
+        opts.banner = "Usage: pf2 report [options] COMMAND"
         opts.on('-h', '--help', 'Prints this help') do
           puts opts
+          return 0
         end
-
         opts.on('-o', '--output FILE', 'Output file') do |path|
           options[:output_file] = path
         end
@@ -37,6 +63,41 @@ module Pf2
       end
 
       return 0
+    end
+
+    def subcommand_serve(argv)
+      options = {}
+      option_parser = OptionParser.new do |opts|
+        opts.banner = "Usage: pf2 serve [options] COMMAND"
+        opts.on('-h', '--help', 'Prints this help') do
+          puts opts
+          return 0
+        end
+        opts.on('-b', '--bind ADDRESS', 'Address to bind') do |host|
+          options[:serve_host] = host
+        end
+        opts.on('-p', '--port PORT', '') do |port|
+          options[:serve_port] = port
+        end
+      end
+      option_parser.parse!(argv)
+
+      if argv.size == 0
+        # No subcommand was specified
+        STDERR.puts option_parser.help
+        return 1
+      end
+
+      # Inject the profiler (pf2/serve) into the target process via RUBYOPT (-r).
+      # This will have no effect if the target process is not Ruby.
+      env = {
+        'RUBYOPT' => '-rpf2/serve'
+      }
+      env['PF2_SERVE_HOST'] = options[:serve_host] if options[:serve_host]
+      env['PF2_SERVE_PORT'] = options[:serve_port] if options[:serve_port]
+      exec(env, *argv) # never returns if succesful
+
+      return 1
     end
   end
 end

--- a/lib/pf2/serve.rb
+++ b/lib/pf2/serve.rb
@@ -1,0 +1,60 @@
+require 'json'
+require 'logger'
+require 'uri'
+require 'webrick'
+
+require_relative '../pf2'
+require_relative './reporter'
+
+module Pf2
+  class Serve
+    CONFIG = {
+      Host: ENV.fetch('PF2_SERVE_HOST', 'localhost'),
+      Port: ENV.fetch('PF2_SERVE_PORT', '51502').to_i, # 1502 = 0xF2 (as in "Pf2")
+      Logger: Logger.new(nil),
+      AccessLog: [],
+    }
+
+    def self.start
+
+      # Ignore Bundler as in `bundle exec`.
+      if File.basename($PROGRAM_NAME) == 'bundle' && ARGV.first == 'exec'
+        return
+      end
+
+      server = WEBrick::HTTPServer.new(CONFIG)
+      server.mount_proc('/profile') do |req, res|
+        profile = Pf2.stop
+        profile = JSON.parse(profile, symbolize_names: true, max_nesting: false)
+        res.header['Content-Type'] = 'application/json'
+        res.header['Access-Control-Allow-Origin'] = '*'
+        res.body = JSON.generate(Pf2::Reporter.new((profile)).emit)
+        Pf2.start
+      end
+
+      Pf2.start
+
+      Thread.new do
+        hostport = "#{server.config[:Host]}:#{server.config[:Port]}"
+        # Print host:port to trigger VS Code's auto port-forwarding feature
+        STDERR.puts "[Pf2] Listening on #{hostport}."
+        STDERR.puts "[Pf2] Open https://profiler.firefox.com/from-url/#{URI.encode_www_form_component("http://#{hostport}/profile")} for visualization."
+        STDERR.puts ""
+        server.start
+      end
+    end
+
+    def self.at_exit
+      STDERR.puts ""
+      STDERR.puts "[Pf2] Script execution complete (Pf2 server is still listening). Hit Ctrl-C to quit."
+
+      # Allow the user to download the profile after the target program exits
+      sleep
+    end
+  end
+end
+
+Pf2::Serve.start
+at_exit do
+  Pf2::Serve.at_exit
+end

--- a/pf2.gemspec
+++ b/pf2.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rake-compiler'
   spec.add_dependency 'rb_sys', '~> 0.9.63'
+  spec.add_dependency 'webrick'
 
   spec.add_development_dependency 'minitest'
 


### PR DESCRIPTION
## Usage

```
$ pf2 serve -- ruby target.rb
```

## Implementation details

`pf2 serve` simply sets `RUBYOPT` to `-rpf2/serve`, which `require`s serve.rb beforehand script execution.