### PR TITLE
Use pthread_getcpuclockid for timer installation

### DIFF
--- a/ext/pf2/src/lib.rs
+++ b/ext/pf2/src/lib.rs
@@ -13,3 +13,5 @@ mod sample;
 mod signal_scheduler;
 mod timer_thread_scheduler;
 mod util;
+
+mod ruby_internal_apis;

--- a/ext/pf2/src/ruby_internal_apis.rs
+++ b/ext/pf2/src/ruby_internal_apis.rs
@@ -1,0 +1,47 @@
+#![allow(non_snake_case)]
+#![allow(non_camel_case_types)]
+
+use libc::{clockid_t, pthread_getcpuclockid, pthread_t};
+use rb_sys::{rb_check_typeddata, rb_data_type_struct, RTypedData, VALUE};
+use std::ffi::{c_char, c_int};
+use std::mem::MaybeUninit;
+
+// Types and structs from Ruby 3.4.0.
+
+type rb_nativethread_id_t = libc::pthread_t;
+
+#[repr(C)]
+struct rb_native_thread {
+    _padding_serial: [c_char; 4], // rb_atomic_t
+    _padding_vm: *mut c_int,      // struct rb_vm_struct
+    thread_id: rb_nativethread_id_t,
+    // ...
+}
+
+#[repr(C)]
+struct rb_thread_struct {
+    _padding_lt_node: [c_char; 16], // struct ccan_list_node
+    _padding_self: VALUE,
+    _padding_ractor: *mut c_int, // rb_ractor_t
+    _padding_vm: *mut c_int,     // rb_vm_t
+    nt: *mut rb_native_thread,
+    // ...
+}
+type rb_thread_t = rb_thread_struct;
+
+/// Reimplementation of the internal RTYPEDDATA_TYPE macro.
+unsafe fn RTYPEDDATA_TYPE(obj: VALUE) -> *const rb_data_type_struct {
+    let typed: *mut RTypedData = obj as *mut RTypedData;
+    (*typed).type_
+}
+
+unsafe fn rb_thread_ptr(thread: VALUE) -> *mut rb_thread_t {
+    unsafe { rb_check_typeddata(thread, RTYPEDDATA_TYPE(thread)) as *mut rb_thread_t }
+}
+
+pub unsafe fn rb_thread_getcpuclockid(thread: VALUE) -> clockid_t {
+    let mut cid: clockid_t = MaybeUninit::zeroed().assume_init();
+    let pthread_id: pthread_t = (*(*rb_thread_ptr(thread)).nt).thread_id;
+    pthread_getcpuclockid(pthread_id, &mut cid as *mut clockid_t);
+    cid
+}

--- a/ext/pf2/src/signal_scheduler/timer_installer.rs
+++ b/ext/pf2/src/signal_scheduler/timer_installer.rs
@@ -1,31 +1,24 @@
-use std::collections::HashMap;
 use std::ffi::c_void;
 use std::mem;
 use std::mem::ManuallyDrop;
 use std::ptr::null_mut;
+use std::sync::Arc;
 use std::sync::{Mutex, RwLock};
-use std::{collections::HashSet, sync::Arc};
 
 use rb_sys::*;
 
-use crate::signal_scheduler::SignalHandlerArgs;
-
 use super::configuration::Configuration;
 use crate::profile::Profile;
+use crate::ruby_internal_apis::rb_thread_getcpuclockid;
+use crate::signal_scheduler::{cstr, SignalHandlerArgs};
 
-// We could avoid deferring the timer creation by combining pthread_getcpuclockid(3) and timer_create(2) here,
-// but we're not doing so since (1) Ruby does not expose the pthread_self() of a Ruby Thread
-// (which is actually stored in th->nt->thread_id), and (2) pthread_getcpuclockid(3) is not portable
-// in the first place (e.g. not available on macOS).
 pub struct TimerInstaller {
     internal: Box<Mutex<Internal>>,
 }
 
 struct Internal {
     configuration: Configuration,
-    registered_pthread_ids: HashSet<libc::pthread_t>,
-    kernel_thread_id_to_ruby_thread_map: HashMap<libc::pid_t, VALUE>,
-    profile: Arc<RwLock<Profile>>,
+    pub profile: Arc<RwLock<Profile>>,
 }
 
 impl TimerInstaller {
@@ -38,25 +31,17 @@ impl TimerInstaller {
         let registrar = Self {
             internal: Box::new(Mutex::new(Internal {
                 configuration: configuration.clone(),
-                registered_pthread_ids: HashSet::new(),
-                kernel_thread_id_to_ruby_thread_map: HashMap::new(),
                 profile,
             })),
         };
 
-        let ptr = Box::into_raw(registrar.internal);
-        unsafe {
-            rb_internal_thread_add_event_hook(
-                Some(Self::on_thread_resume),
-                RUBY_INTERNAL_THREAD_EVENT_RESUMED,
-                ptr as *mut c_void,
-            );
-            // Spawn a no-op Thread to fire the event hook
-            // (at least 2 Ruby Threads must be active for the RESUMED hook to be fired)
-            rb_thread_create(Some(Self::do_nothing), null_mut());
-        };
+        for ruby_thread in configuration.target_ruby_threads.iter() {
+            let ruby_thread: VALUE = *ruby_thread;
+            registrar.register_timer_to_ruby_thread(ruby_thread);
+        }
 
         if configuration.track_new_threads {
+            let ptr = Box::into_raw(registrar.internal);
             unsafe {
                 rb_internal_thread_add_event_hook(
                     Some(Self::on_thread_start),
@@ -65,56 +50,6 @@ impl TimerInstaller {
                 );
             };
         }
-    }
-
-    unsafe extern "C" fn do_nothing(_: *mut c_void) -> VALUE {
-        Qnil.into()
-    }
-
-    // Thread resume callback
-    unsafe extern "C" fn on_thread_resume(
-        _flag: rb_event_flag_t,
-        data: *const rb_internal_thread_event_data,
-        custom_data: *mut c_void,
-    ) {
-        // The SignalScheduler (as a Ruby obj) should be passed as custom_data
-        let internal =
-            unsafe { ManuallyDrop::new(Box::from_raw(custom_data as *mut Mutex<Internal>)) };
-        let mut internal = internal.lock().unwrap();
-
-        // Check if the current thread is a target Ruby Thread
-        let current_ruby_thread: VALUE = unsafe { (*data).thread };
-        if !internal
-            .configuration
-            .target_ruby_threads
-            .contains(&current_ruby_thread)
-        {
-            return;
-        }
-
-        // Check if the current thread is already registered
-        let current_pthread_id = unsafe { libc::pthread_self() };
-        if internal
-            .registered_pthread_ids
-            .contains(&current_pthread_id)
-        {
-            return;
-        }
-
-        // Record the pthread ID of the current thread
-        internal.registered_pthread_ids.insert(current_pthread_id);
-        // Keep a mapping from kernel thread ID to Ruby Thread
-        internal
-            .kernel_thread_id_to_ruby_thread_map
-            .insert(unsafe { libc::gettid() }, current_ruby_thread);
-
-        Self::register_timer_to_current_thread(
-            &internal.configuration,
-            &internal.profile,
-            &internal.kernel_thread_id_to_ruby_thread_map,
-        );
-
-        // TODO: Remove the hook when all threads have been registered
     }
 
     // Thread resume callback
@@ -135,23 +70,13 @@ impl TimerInstaller {
             .insert(current_ruby_thread);
     }
 
-    // Creates a new POSIX timer which invocates sampling for the thread that called this function.
-    fn register_timer_to_current_thread(
-        configuration: &Configuration,
-        profile: &Arc<RwLock<Profile>>,
-        kernel_thread_id_to_ruby_thread_map: &HashMap<libc::pid_t, VALUE>,
-    ) {
-        let current_pthread_id = unsafe { libc::pthread_self() };
-        let context_ruby_thread: VALUE = unsafe {
-            *(kernel_thread_id_to_ruby_thread_map
-                .get(&(libc::gettid()))
-                .unwrap())
-        };
+    fn register_timer_to_ruby_thread(&self, ruby_thread: VALUE) {
+        let internal = self.internal.lock().unwrap();
 
         // NOTE: This Box is never dropped
         let signal_handler_args = Box::new(SignalHandlerArgs {
-            profile: Arc::clone(profile),
-            context_ruby_thread,
+            profile: Arc::clone(&internal.profile),
+            context_ruby_thread: ruby_thread,
         });
 
         // Create a signal event
@@ -159,29 +84,37 @@ impl TimerInstaller {
         // Note: SIGEV_THREAD_ID is Linux-specific. In other platforms, we would need to
         // "tranpoline" the signal as any pthread can receive the signal.
         sigevent.sigev_notify = libc::SIGEV_THREAD_ID;
-        sigevent.sigev_notify_thread_id =
-            unsafe { libc::syscall(libc::SYS_gettid).try_into().unwrap() }; // The kernel thread ID
+        sigevent.sigev_notify_thread_id = i32::try_from(unsafe {
+            rb_num2int(rb_funcall(
+                ruby_thread,
+                rb_intern(cstr!("native_thread_id")), // kernel thread ID
+                0,
+            ))
+        })
+        .unwrap();
         sigevent.sigev_signo = libc::SIGALRM;
         // Pass required args to the signal handler
         sigevent.sigev_value.sival_ptr = Box::into_raw(signal_handler_args) as *mut c_void;
 
         // Create and configure timer to fire every _interval_ ms of CPU time
         let mut timer: libc::timer_t = unsafe { mem::zeroed() };
-        let clockid = match configuration.time_mode {
-            crate::signal_scheduler::TimeMode::CpuTime => libc::CLOCK_THREAD_CPUTIME_ID,
+        let clockid = match internal.configuration.time_mode {
+            crate::signal_scheduler::TimeMode::CpuTime => unsafe {
+                rb_thread_getcpuclockid(ruby_thread)
+            },
             crate::signal_scheduler::TimeMode::WallTime => libc::CLOCK_MONOTONIC,
         };
         let err = unsafe { libc::timer_create(clockid, &mut sigevent, &mut timer) };
         if err != 0 {
             panic!("timer_create failed: {}", err);
         }
-        let itimerspec = Self::duration_to_itimerspec(&configuration.interval);
+        let itimerspec = Self::duration_to_itimerspec(&internal.configuration.interval);
         let err = unsafe { libc::timer_settime(timer, 0, &itimerspec, null_mut()) };
         if err != 0 {
             panic!("timer_settime failed: {}", err);
         }
 
-        log::debug!("timer registered for thread {}", current_pthread_id);
+        log::debug!("timer registered for thread {}", ruby_thread);
     }
 
     fn duration_to_itimerspec(duration: &std::time::Duration) -> libc::itimerspec {

--- a/ext/pf2/src/signal_scheduler/timer_installer.rs
+++ b/ext/pf2/src/signal_scheduler/timer_installer.rs
@@ -30,14 +30,14 @@ impl TimerInstaller {
         configuration: Configuration,
         profile: Arc<RwLock<Profile>>,
     ) {
-        let registrar = Self {
+        let installer = Self {
             internal: Box::new(Mutex::new(Internal {
                 configuration: configuration.clone(),
                 profile,
             })),
         };
 
-        if let Ok(internal) = registrar.internal.try_lock() {
+        if let Ok(internal) = installer.internal.try_lock() {
             for ruby_thread in configuration.target_ruby_threads.iter() {
                 let ruby_thread: VALUE = *ruby_thread;
                 internal.register_timer_to_ruby_thread(ruby_thread, false);
@@ -45,7 +45,7 @@ impl TimerInstaller {
         }
 
         if configuration.track_new_threads {
-            let ptr = Box::into_raw(registrar.internal);
+            let ptr = Box::into_raw(installer.internal);
             unsafe {
                 rb_internal_thread_add_event_hook(
                     Some(Self::on_thread_start),


### PR DESCRIPTION
The timer installation procedure needed to run on the target pthread in
order to use the per-thread CPU time timer. This limitation came from
the fact that Ruby not exposing the underlying pthread's ID which can be
passed to pthread_getcpuclockid() (note that `Thread#native_thread_id`
returns the kernel thread ID, which is different from the pthread ID).

This patch overcomes this by copying CRuby-internal structs into our
code, enabling access to `rb_thread_t->nt->thread_id`. We lose some
robustness here since we will now need to catch up with changes on the
Ruby side, but we'll gain simpler code and more predictable behavior
(less callbacks!).