### PR TITLE
Implement "weaving" of native frames into stack 

### DIFF
--- a/ext/pf2/src/ruby_internal.rs
+++ b/ext/pf2/src/ruby_internal.rs
@@ -1,0 +1,29 @@
+#![allow(non_snake_case)]
+#![allow(non_camel_case_types)]
+
+use rb_sys::VALUE;
+
+use std::ffi::{c_char, c_int, c_void};
+
+#[repr(C)]
+pub struct rb_callable_method_entry_struct {
+    /* same fields with rb_method_entry_t */
+    pub flags: VALUE,
+    _padding_defined_class: VALUE,
+    pub def: *mut rb_method_definition_struct,
+    // ...
+}
+
+#[repr(C)]
+pub struct rb_method_definition_struct {
+    pub type_: c_int,
+    _padding: [c_char; 4],
+    pub cfunc: rb_method_cfunc_struct,
+    // ...
+}
+
+#[repr(C)]
+pub struct rb_method_cfunc_struct {
+    pub func: *mut c_void,
+    // ...
+}

--- a/ext/pf2/src/ruby_internal_apis.rs
+++ b/ext/pf2/src/ruby_internal_apis.rs
@@ -3,10 +3,33 @@
 
 use libc::{clockid_t, pthread_getcpuclockid, pthread_t};
 use rb_sys::{rb_check_typeddata, rb_data_type_struct, RTypedData, VALUE};
-use std::ffi::{c_char, c_int};
+use std::ffi::{c_char, c_int, c_void};
 use std::mem::MaybeUninit;
 
 // Types and structs from Ruby 3.4.0.
+
+#[repr(C)]
+pub struct rb_callable_method_entry_struct {
+    /* same fields with rb_method_entry_t */
+    pub flags: VALUE,
+    _padding_defined_class: VALUE,
+    pub def: *mut rb_method_definition_struct,
+    // ...
+}
+
+#[repr(C)]
+pub struct rb_method_definition_struct {
+    pub type_: c_int,
+    _padding: [c_char; 4],
+    pub cfunc: rb_method_cfunc_struct,
+    // ...
+}
+
+#[repr(C)]
+pub struct rb_method_cfunc_struct {
+    pub func: *mut c_void,
+    // ...
+}
 
 type rb_nativethread_id_t = libc::pthread_t;
 


### PR DESCRIPTION
This patch implements the merging procedure of native frames into the resulting stack, which is hereby called _weaving_.

The algorithm boils down to identifying where the Ruby -> C switch occured, and vice versa. When we find a Cfunc frame when digging down the Ruby stack, we try to find a match in the native stack based on the function address. This is done by peeking into the rb_callable_method_entry_struct returned from rb_profile_thread_frames() (which is not public, so I copied struct definitions from ruby/ruby), making this implementation obviously unstable.

The opposite (finding C -> Ruby transitions) is rather easy; we just mark rb_vm_exec() calls as the switch.