### PR TITLE
Replace `track_new_threads` with `track_all_threads` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+### Added
+
+- New option: `track_all_threads`
+  - When true, all Threads will be tracked regardless of the `threads` option.
+
+### Removed
+
+- The `track_new_threads` option was removed in favor of the `track_all_threads` option.
+
 
 ## [0.3.0] - 2024-02-05
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Pf2.start(
   threads: [],            # Array<Thread>: A list of Ruby Threads to be tracked (default: `Thread.list`)
   time_mode: :cpu,        # `:cpu` or `:wall`: The sampling timer's mode
                           # (default: `:cpu` for SignalScheduler, `:wall` for TimerThreadScheduler)
-  track_new_threads: true # Boolean: Whether to automatically track Threads spawned after profiler start
+  track_all_threads: true # Boolean: Whether to track all Threads regardless of `threads` option
                           # (default: false)
 )
 ```

--- a/ext/pf2/src/signal_scheduler.rs
+++ b/ext/pf2/src/signal_scheduler.rs
@@ -56,7 +56,7 @@ impl SignalScheduler {
                     rb_intern(cstr!("interval_ms")),
                     rb_intern(cstr!("threads")),
                     rb_intern(cstr!("time_mode")),
-                    rb_intern(cstr!("track_new_threads")),
+                    rb_intern(cstr!("track_all_threads")),
                 ]
                 .as_mut_ptr(),
                 0,
@@ -99,7 +99,7 @@ impl SignalScheduler {
         } else {
             configuration::TimeMode::CpuTime
         };
-        let track_new_threads: bool = if kwargs_values[3] != Qundef as VALUE {
+        let track_all_threads: bool = if kwargs_values[3] != Qundef as VALUE {
             RTEST(kwargs_values[3])
         } else {
             false
@@ -117,7 +117,7 @@ impl SignalScheduler {
             interval,
             target_ruby_threads,
             time_mode,
-            track_new_threads,
+            track_all_threads,
         });
 
         Qnil.into()

--- a/ext/pf2/src/signal_scheduler/configuration.rs
+++ b/ext/pf2/src/signal_scheduler/configuration.rs
@@ -9,7 +9,7 @@ pub struct Configuration {
     pub interval: Duration,
     pub time_mode: TimeMode,
     pub target_ruby_threads: HashSet<VALUE>,
-    pub track_new_threads: bool,
+    pub track_all_threads: bool,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
The `track_new_threads` option relied on a rather complex implementation depending on the RUBY_INTERNAL_THREAD_EVERT_STARTED hook being executed on pthreads of newly created Ruby Threads.

As tracking all active threads would be sufficient for use cases of `track_new_threads`, I replaced the option with a slightly different `track_all_threads`.