### PR TITLE
Show function location (file:line) in report

### DIFF
--- a/lib/pf2/reporter.rb
+++ b/lib/pf2/reporter.rb
@@ -155,7 +155,7 @@ module Pf2
           ret[:func] << i # TODO
           ret[:inner_window_id] << nil
           ret[:implementation] << nil
-          ret[:line] << nil
+          ret[:line] << frame[:callsite_lineno]
           ret[:column] << nil
           ret[:optimizations] << nil
           ret[:inline_depth] << 0
@@ -186,8 +186,8 @@ module Pf2
           ret[:is_js] << !native
           ret[:relevant_for_js] << false
           ret[:resource] << -1
-          ret[:file_name] << nil
-          ret[:line_number] << nil
+          ret[:file_name] << string_id(frame[:file_name])
+          ret[:line_number] << frame[:function_first_lineno]
           ret[:column_number] << nil
 
           @func_id_map[id] = i


### PR DESCRIPTION
Show values obtained from `rb_profile_frame_path()` and `rb_profile_frame_first_lineno()` in the report.
<img width="673" alt="image" src="https://github.com/osyoyu/pf2/assets/1992308/152d54ed-bc67-4443-80c6-e8c94bb10c2e">

For native frames, we'll need to switch from `backtrace_syminfo()` to `backtrace_pcinfo()` which should return linenos and file paths.