### PR TITLE
Introduce Pf2::Session and hide Schedulers from Ruby code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - `pf2 serve` subcommand
   - `pf2 serve -- ruby target.rb`
   - Profile programs without any change
+- Introduce `Pf2::Session` (https://github.com/osyoyu/pf2/pull/16)
+  - `Session` will be responsible for managing Profiles and Schedulers
+
+### Removed
+
+- `Pf2::SignalScheduler` and `Pf2::TimerThreadScheduler` are now hidden from Ruby.
 
 
 ## [0.4.0] - 2024-03-22

--- a/ext/pf2/src/lib.rs
+++ b/ext/pf2/src/lib.rs
@@ -9,6 +9,7 @@ mod profile;
 mod profile_serializer;
 mod ringbuffer;
 mod sample;
+mod session;
 #[cfg(target_os = "linux")]
 mod signal_scheduler;
 mod timer_thread_scheduler;

--- a/ext/pf2/src/lib.rs
+++ b/ext/pf2/src/lib.rs
@@ -9,6 +9,7 @@ mod profile;
 mod profile_serializer;
 mod ringbuffer;
 mod sample;
+mod scheduler;
 mod session;
 #[cfg(target_os = "linux")]
 mod signal_scheduler;

--- a/ext/pf2/src/ruby_init.rs
+++ b/ext/pf2/src/ruby_init.rs
@@ -2,6 +2,7 @@
 
 use rb_sys::*;
 
+use crate::session::ruby_object::SessionRubyObject;
 #[cfg(target_os = "linux")]
 use crate::signal_scheduler::SignalScheduler;
 use crate::timer_thread_scheduler::TimerThreadScheduler;
@@ -20,6 +21,15 @@ extern "C" fn Init_pf2() {
 
     unsafe {
         let rb_mPf2: VALUE = rb_define_module(cstr!("Pf2"));
+
+        let rb_mPf2_Session = rb_define_class_under(rb_mPf2, cstr!("Session"), rb_cObject);
+        rb_define_alloc_func(rb_mPf2_Session, Some(SessionRubyObject::rb_alloc));
+        rb_define_method(
+            rb_mPf2_Session,
+            cstr!("initialize"),
+            Some(to_ruby_cfunc_with_args(SessionRubyObject::rb_initialize)),
+            -1,
+        );
 
         #[cfg(target_os = "linux")]
         {

--- a/ext/pf2/src/ruby_init.rs
+++ b/ext/pf2/src/ruby_init.rs
@@ -3,7 +3,6 @@
 use rb_sys::*;
 
 use crate::session::ruby_object::SessionRubyObject;
-use crate::timer_thread_scheduler::TimerThreadScheduler;
 use crate::util::*;
 
 #[allow(non_snake_case)]
@@ -38,31 +37,6 @@ extern "C" fn Init_pf2() {
             rb_mPf2_Session,
             cstr!("stop"),
             Some(to_ruby_cfunc_with_no_args(SessionRubyObject::rb_stop)),
-            0,
-        );
-
-        let rb_mPf2_TimerThreadScheduler =
-            rb_define_class_under(rb_mPf2, cstr!("TimerThreadScheduler"), rb_cObject);
-        rb_define_alloc_func(
-            rb_mPf2_TimerThreadScheduler,
-            Some(TimerThreadScheduler::rb_alloc),
-        );
-        rb_define_method(
-            rb_mPf2_TimerThreadScheduler,
-            cstr!("initialize"),
-            Some(to_ruby_cfunc_with_args(TimerThreadScheduler::rb_initialize)),
-            -1,
-        );
-        rb_define_method(
-            rb_mPf2_TimerThreadScheduler,
-            cstr!("start"),
-            Some(to_ruby_cfunc_with_no_args(TimerThreadScheduler::rb_start)),
-            0,
-        );
-        rb_define_method(
-            rb_mPf2_TimerThreadScheduler,
-            cstr!("stop"),
-            Some(to_ruby_cfunc_with_no_args(TimerThreadScheduler::rb_stop)),
             0,
         );
     }

--- a/ext/pf2/src/ruby_init.rs
+++ b/ext/pf2/src/ruby_init.rs
@@ -3,8 +3,6 @@
 use rb_sys::*;
 
 use crate::session::ruby_object::SessionRubyObject;
-#[cfg(target_os = "linux")]
-use crate::signal_scheduler::SignalScheduler;
 use crate::timer_thread_scheduler::TimerThreadScheduler;
 use crate::util::*;
 
@@ -30,31 +28,18 @@ extern "C" fn Init_pf2() {
             Some(to_ruby_cfunc_with_args(SessionRubyObject::rb_initialize)),
             -1,
         );
-
-        #[cfg(target_os = "linux")]
-        {
-            let rb_mPf2_SignalScheduler =
-                rb_define_class_under(rb_mPf2, cstr!("SignalScheduler"), rb_cObject);
-            rb_define_alloc_func(rb_mPf2_SignalScheduler, Some(SignalScheduler::rb_alloc));
-            rb_define_method(
-                rb_mPf2_SignalScheduler,
-                cstr!("initialize"),
-                Some(to_ruby_cfunc_with_args(SignalScheduler::rb_initialize)),
-                -1,
-            );
-            rb_define_method(
-                rb_mPf2_SignalScheduler,
-                cstr!("start"),
-                Some(to_ruby_cfunc_with_no_args(SignalScheduler::rb_start)),
-                0,
-            );
-            rb_define_method(
-                rb_mPf2_SignalScheduler,
-                cstr!("stop"),
-                Some(to_ruby_cfunc_with_no_args(SignalScheduler::rb_stop)),
-                0,
-            );
-        }
+        rb_define_method(
+            rb_mPf2_Session,
+            cstr!("start"),
+            Some(to_ruby_cfunc_with_no_args(SessionRubyObject::rb_start)),
+            0,
+        );
+        rb_define_method(
+            rb_mPf2_Session,
+            cstr!("stop"),
+            Some(to_ruby_cfunc_with_no_args(SessionRubyObject::rb_stop)),
+            0,
+        );
 
         let rb_mPf2_TimerThreadScheduler =
             rb_define_class_under(rb_mPf2, cstr!("TimerThreadScheduler"), rb_cObject);

--- a/ext/pf2/src/scheduler.rs
+++ b/ext/pf2/src/scheduler.rs
@@ -1,0 +1,9 @@
+use rb_sys::{size_t, VALUE};
+
+pub trait Scheduler {
+    fn start(&mut self) -> VALUE;
+    fn stop(&mut self) -> VALUE;
+    fn dmark(&self);
+    fn dfree(&self);
+    fn dsize(&self) -> size_t;
+}

--- a/ext/pf2/src/session.rs
+++ b/ext/pf2/src/session.rs
@@ -11,6 +11,7 @@ use rb_sys::*;
 use self::configuration::Configuration;
 use crate::scheduler::Scheduler;
 use crate::signal_scheduler::SignalScheduler;
+use crate::timer_thread_scheduler::TimerThreadScheduler;
 use crate::util::*;
 
 pub struct Session {
@@ -57,10 +58,10 @@ impl Session {
             track_all_threads,
         };
 
-        let scheduler = match configuration.scheduler {
+        let scheduler: Box<dyn Scheduler> = match configuration.scheduler {
             configuration::Scheduler::Signal => Box::new(SignalScheduler::new(&configuration)),
             configuration::Scheduler::TimerThread => {
-                todo!("implement TimerThread support")
+                Box::new(TimerThreadScheduler::new(&configuration))
             }
         };
 
@@ -130,8 +131,7 @@ impl Session {
             // Return default
             return false;
         }
-
-        RTEST(value)
+        todo!("Implement track_all_threads");
     }
 
     fn parse_option_scheduler(value: VALUE) -> configuration::Scheduler {

--- a/ext/pf2/src/session.rs
+++ b/ext/pf2/src/session.rs
@@ -1,0 +1,124 @@
+pub mod configuration;
+pub mod ruby_object;
+
+use std::collections::HashSet;
+use std::ffi::{c_int, CStr};
+use std::str::FromStr as _;
+use std::time::Duration;
+
+use rb_sys::*;
+
+use self::configuration::Configuration;
+use crate::util::*;
+
+pub struct Session {
+    pub configuration: Configuration,
+}
+
+impl Session {
+    pub fn new_from_rb_initialize(argc: c_int, argv: *const VALUE, _rbself: VALUE) -> Self {
+        // Parse arguments
+        let kwargs: VALUE = Qnil.into();
+        unsafe {
+            rb_scan_args(argc, argv, cstr!(":"), &kwargs);
+        };
+        let mut kwargs_values: [VALUE; 4] = [Qnil.into(); 4];
+        unsafe {
+            rb_get_kwargs(
+                kwargs,
+                [
+                    rb_intern(cstr!("interval_ms")),
+                    rb_intern(cstr!("threads")),
+                    rb_intern(cstr!("time_mode")),
+                    rb_intern(cstr!("track_all_threads")),
+                ]
+                .as_mut_ptr(),
+                0,
+                4,
+                kwargs_values.as_mut_ptr(),
+            );
+        };
+
+        let interval = Self::parse_option_interval_ms(kwargs_values[0]);
+        let threads = Self::parse_option_threads(kwargs_values[1]);
+        let time_mode = Self::parse_option_time_mode(kwargs_values[2]);
+        let track_all_threads = Self::parse_option_track_all_threads(kwargs_values[3]);
+
+        Session {
+            configuration: Configuration {
+                interval,
+                target_ruby_threads: threads,
+                time_mode,
+                track_all_threads,
+            },
+        }
+    }
+
+    fn parse_option_interval_ms(value: VALUE) -> Duration {
+        if value == Qundef as VALUE {
+            // Return default
+            return configuration::DEFAULT_INTERVAL;
+        }
+
+        let interval_ms = unsafe { rb_num2long(value) };
+        Duration::from_millis(interval_ms.try_into().unwrap_or_else(|_| {
+            eprintln!(
+                "[Pf2] Warning: Specified interval ({}) is not valid. Using default value (49ms).",
+                interval_ms
+            );
+            49
+        }))
+    }
+
+    fn parse_option_threads(value: VALUE) -> HashSet<VALUE> {
+        let threads = if value == Qundef as VALUE {
+            // Use Thread.list (all active Threads)
+            unsafe { rb_funcall(rb_cThread, rb_intern(cstr!("list")), 0) }
+        } else {
+            value
+        };
+
+        let mut set: HashSet<VALUE> = HashSet::new();
+        unsafe {
+            for i in 0..RARRAY_LEN(threads) {
+                set.insert(rb_ary_entry(threads, i));
+            }
+        }
+        set
+    }
+
+    fn parse_option_time_mode(value: VALUE) -> configuration::TimeMode {
+        if value == Qundef as VALUE {
+            // Return default
+            return configuration::DEFAULT_TIME_MODE;
+        }
+
+        let specified_mode = unsafe {
+            let mut str = rb_funcall(value, rb_intern(cstr!("to_s")), 0);
+            let ptr = rb_string_value_ptr(&mut str);
+            CStr::from_ptr(ptr).to_str().unwrap()
+        };
+        configuration::TimeMode::from_str(specified_mode).unwrap_or_else(|_| {
+            // Raise an ArgumentError if the mode is invalid
+            unsafe {
+                rb_raise(
+                    rb_eArgError,
+                    cstr!("Invalid time mode. Valid values are 'cpu' and 'wall'."),
+                )
+            }
+        })
+    }
+
+    fn parse_option_track_all_threads(value: VALUE) -> bool {
+        if value == Qundef as VALUE {
+            // Return default
+            return false;
+        }
+
+        RTEST(value)
+    }
+
+    pub fn dmark(&self) {
+        // No-op
+    }
+}

--- a/ext/pf2/src/session.rs
+++ b/ext/pf2/src/session.rs
@@ -20,7 +20,7 @@ pub struct Session {
 }
 
 impl Session {
-    pub fn new_from_rb_initialize(argc: c_int, argv: *const VALUE, _rbself: VALUE) -> Self {
+    pub fn new_from_rb_initialize(argc: c_int, argv: *const VALUE, rbself: VALUE) -> Self {
         // Parse arguments
         let kwargs: VALUE = Qnil.into();
         unsafe {
@@ -57,6 +57,11 @@ impl Session {
             time_mode,
             track_all_threads,
         };
+
+        // Store configuration as a Ruby Hash for convenience
+        unsafe {
+            rb_iv_set(rbself, cstr!("@configuration"), configuration.to_rb_hash());
+        }
 
         let scheduler: Box<dyn Scheduler> = match configuration.scheduler {
             configuration::Scheduler::Signal => Box::new(SignalScheduler::new(&configuration)),

--- a/ext/pf2/src/session/configuration.rs
+++ b/ext/pf2/src/session/configuration.rs
@@ -4,15 +4,35 @@ use std::time::Duration;
 
 use rb_sys::VALUE;
 
+pub const DEFAULT_SCHEDULER: Scheduler = Scheduler::Signal;
 pub const DEFAULT_INTERVAL: Duration = Duration::from_millis(49);
 pub const DEFAULT_TIME_MODE: TimeMode = TimeMode::CpuTime;
 
 #[derive(Clone, Debug)]
 pub struct Configuration {
+    pub scheduler: Scheduler,
     pub interval: Duration,
     pub time_mode: TimeMode,
     pub target_ruby_threads: HashSet<VALUE>,
     pub track_all_threads: bool,
+}
+
+#[derive(Clone, Debug)]
+pub enum Scheduler {
+    Signal,
+    TimerThread,
+}
+
+impl FromStr for Scheduler {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "signal" => Ok(Self::Signal),
+            "timer_thread" => Ok(Self::TimerThread),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/ext/pf2/src/session/configuration.rs
+++ b/ext/pf2/src/session/configuration.rs
@@ -1,0 +1,34 @@
+use std::collections::HashSet;
+use std::str::FromStr;
+use std::time::Duration;
+
+use rb_sys::VALUE;
+
+pub const DEFAULT_INTERVAL: Duration = Duration::from_millis(49);
+pub const DEFAULT_TIME_MODE: TimeMode = TimeMode::CpuTime;
+
+#[derive(Clone, Debug)]
+pub struct Configuration {
+    pub interval: Duration,
+    pub time_mode: TimeMode,
+    pub target_ruby_threads: HashSet<VALUE>,
+    pub track_all_threads: bool,
+}
+
+#[derive(Clone, Debug)]
+pub enum TimeMode {
+    CpuTime,
+    WallTime,
+}
+
+impl FromStr for TimeMode {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cpu" => Ok(Self::CpuTime),
+            "wall" => Ok(Self::WallTime),
+            _ => Err(()),
+        }
+    }
+}

--- a/ext/pf2/src/session/ruby_object.rs
+++ b/ext/pf2/src/session/ruby_object.rs
@@ -1,0 +1,74 @@
+use std::ffi::{c_int, c_void};
+use std::mem;
+use std::mem::ManuallyDrop;
+use std::ptr::null_mut;
+
+use rb_sys::*;
+
+use crate::util::cstr;
+
+use super::Session;
+
+pub struct SessionRubyObject {
+    session: Option<Session>,
+}
+
+impl SessionRubyObject {
+    pub unsafe extern "C" fn rb_initialize(
+        argc: c_int,
+        argv: *const VALUE,
+        rbself: VALUE,
+    ) -> VALUE {
+        let mut obj = unsafe { Self::get_struct_from(rbself) };
+        obj.session = Some(Session::new_from_rb_initialize(argc, argv, rbself));
+        Qnil.into()
+    }
+
+    // Extract the SessionRubyObject struct from a Ruby object
+    unsafe fn get_struct_from(obj: VALUE) -> ManuallyDrop<Box<Self>> {
+        unsafe {
+            let ptr = rb_check_typeddata(obj, &RBDATA);
+            ManuallyDrop::new(Box::from_raw(ptr as *mut SessionRubyObject))
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub unsafe extern "C" fn rb_alloc(_rbself: VALUE) -> VALUE {
+        let obj = Box::new(SessionRubyObject { session: None });
+
+        let rb_mPf2: VALUE = rb_define_module(cstr!("Pf2"));
+        let rb_cSession = rb_define_class_under(rb_mPf2, cstr!("Session"), rb_cObject);
+        // Wrap the struct into a Ruby object
+        rb_data_typed_object_wrap(rb_cSession, Box::into_raw(obj) as *mut c_void, &RBDATA)
+    }
+
+    unsafe extern "C" fn dmark(ptr: *mut c_void) {
+        let collector = ManuallyDrop::new(Box::from_raw(ptr as *mut SessionRubyObject));
+        if let Some(session) = &collector.session {
+            session.dmark()
+        }
+    }
+
+    unsafe extern "C" fn dfree(ptr: *mut c_void) {
+        drop(Box::from_raw(ptr as *mut SessionRubyObject));
+    }
+
+    unsafe extern "C" fn dsize(_: *const c_void) -> size_t {
+        // FIXME: Report something better
+        mem::size_of::<SessionRubyObject>() as size_t
+    }
+}
+
+static mut RBDATA: rb_data_type_t = rb_data_type_t {
+    wrap_struct_name: cstr!("SessionRubyObject"),
+    function: rb_data_type_struct__bindgen_ty_1 {
+        dmark: Some(SessionRubyObject::dmark),
+        dfree: Some(SessionRubyObject::dfree),
+        dsize: Some(SessionRubyObject::dsize),
+        dcompact: None,
+        reserved: [null_mut(); 1],
+    },
+    parent: null_mut(),
+    data: null_mut(),
+    flags: 0,
+};

--- a/ext/pf2/src/session/ruby_object.rs
+++ b/ext/pf2/src/session/ruby_object.rs
@@ -24,6 +24,22 @@ impl SessionRubyObject {
         Qnil.into()
     }
 
+    pub unsafe extern "C" fn rb_start(rbself: VALUE) -> VALUE {
+        let mut obj = Self::get_struct_from(rbself);
+        match &mut obj.session {
+            Some(session) => session.start(),
+            None => panic!("Session is not initialized"),
+        }
+    }
+
+    pub unsafe extern "C" fn rb_stop(rbself: VALUE) -> VALUE {
+        let mut obj = Self::get_struct_from(rbself);
+        match &mut obj.session {
+            Some(session) => session.stop(),
+            None => panic!("Session is not initialized"),
+        }
+    }
+
     // Extract the SessionRubyObject struct from a Ruby object
     unsafe fn get_struct_from(obj: VALUE) -> ManuallyDrop<Box<Self>> {
         unsafe {

--- a/ext/pf2/src/signal_scheduler.rs
+++ b/ext/pf2/src/signal_scheduler.rs
@@ -1,19 +1,17 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
-mod configuration;
 mod timer_installer;
 
-use self::configuration::{Configuration, TimeMode};
 use self::timer_installer::TimerInstaller;
 use crate::profile::Profile;
 use crate::profile_serializer::ProfileSerializer;
 use crate::sample::Sample;
+use crate::scheduler::Scheduler;
+use crate::session::configuration::Configuration;
 
 use core::panic;
-use std::collections::HashSet;
-use std::ffi::{c_int, c_void, CStr, CString};
+use std::ffi::{c_int, CString};
 use std::mem::ManuallyDrop;
-use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
@@ -25,7 +23,7 @@ use crate::util::*;
 
 #[derive(Debug)]
 pub struct SignalScheduler {
-    configuration: Option<configuration::Configuration>,
+    configuration: Configuration,
     profile: Option<Arc<RwLock<Profile>>>,
 }
 
@@ -34,102 +32,14 @@ pub struct SignalHandlerArgs {
     context_ruby_thread: VALUE,
 }
 
-impl SignalScheduler {
-    fn new() -> Self {
-        Self {
-            configuration: None,
-            profile: None,
-        }
-    }
-
-    fn initialize(&mut self, argc: c_int, argv: *const VALUE, _rbself: VALUE) -> VALUE {
-        // Parse arguments
-        let kwargs: VALUE = Qnil.into();
-        unsafe {
-            rb_scan_args(argc, argv, cstr!(":"), &kwargs);
-        };
-        let mut kwargs_values: [VALUE; 4] = [Qnil.into(); 4];
-        unsafe {
-            rb_get_kwargs(
-                kwargs,
-                [
-                    rb_intern(cstr!("interval_ms")),
-                    rb_intern(cstr!("threads")),
-                    rb_intern(cstr!("time_mode")),
-                    rb_intern(cstr!("track_all_threads")),
-                ]
-                .as_mut_ptr(),
-                0,
-                4,
-                kwargs_values.as_mut_ptr(),
-            );
-        };
-        let interval: Duration = if kwargs_values[0] != Qundef as VALUE {
-            let interval_ms = unsafe { rb_num2long(kwargs_values[0]) };
-            Duration::from_millis(interval_ms.try_into().unwrap_or_else(|_| {
-                eprintln!(
-                    "[Pf2] Warning: Specified interval ({}) is not valid. Using default value (49ms).",
-                    interval_ms
-                );
-                49
-            }))
-        } else {
-            Duration::from_millis(49)
-        };
-        let threads: VALUE = if kwargs_values[1] != Qundef as VALUE {
-            kwargs_values[1]
-        } else {
-            unsafe { rb_funcall(rb_cThread, rb_intern(cstr!("list")), 0) }
-        };
-        let time_mode: configuration::TimeMode = if kwargs_values[2] != Qundef as VALUE {
-            let specified_mode = unsafe {
-                let mut str = rb_funcall(kwargs_values[2], rb_intern(cstr!("to_s")), 0);
-                let ptr = rb_string_value_ptr(&mut str);
-                CStr::from_ptr(ptr).to_str().unwrap()
-            };
-            configuration::TimeMode::from_str(specified_mode).unwrap_or_else(|_| {
-                // Raise an ArgumentError
-                unsafe {
-                    rb_raise(
-                        rb_eArgError,
-                        cstr!("Invalid time mode. Valid values are 'cpu' and 'wall'."),
-                    )
-                }
-            })
-        } else {
-            configuration::TimeMode::CpuTime
-        };
-        let track_all_threads: bool = if kwargs_values[3] != Qundef as VALUE {
-            RTEST(kwargs_values[3])
-        } else {
-            false
-        };
-
-        let mut target_ruby_threads = HashSet::new();
-        unsafe {
-            for i in 0..RARRAY_LEN(threads) {
-                let ruby_thread: VALUE = rb_ary_entry(threads, i);
-                target_ruby_threads.insert(ruby_thread);
-            }
-        }
-
-        self.configuration = Some(Configuration {
-            interval,
-            target_ruby_threads,
-            time_mode,
-            track_all_threads,
-        });
-
-        Qnil.into()
-    }
-
-    fn start(&mut self, _rbself: VALUE) -> VALUE {
+impl Scheduler for SignalScheduler {
+    fn start(&mut self) -> VALUE {
         let profile = Arc::new(RwLock::new(Profile::new()));
         self.start_profile_buffer_flusher_thread(&profile);
         self.install_signal_handler();
 
         TimerInstaller::install_timer_to_ruby_threads(
-            self.configuration.as_ref().unwrap().clone(), // FIXME: don't clone
+            self.configuration.clone(),
             Arc::clone(&profile),
         );
 
@@ -138,7 +48,7 @@ impl SignalScheduler {
         Qtrue.into()
     }
 
-    fn stop(&mut self, _rbself: VALUE) -> VALUE {
+    fn stop(&mut self) -> VALUE {
         if let Some(profile) = &self.profile {
             // Finalize
             match profile.try_write() {
@@ -159,6 +69,37 @@ impl SignalScheduler {
             unsafe { rb_str_new_cstr(serialized.as_ptr()) }
         } else {
             panic!("stop() called before start()");
+        }
+    }
+
+    fn dmark(&self) {
+        if let Some(profile) = &self.profile {
+            match profile.read() {
+                Ok(profile) => unsafe {
+                    profile.dmark();
+                },
+                Err(_) => {
+                    panic!("[pf2 FATAL] dmark: Failed to acquire profile lock.");
+                }
+            }
+        }
+    }
+
+    fn dfree(&self) {
+        // No-op
+    }
+
+    fn dsize(&self) -> size_t {
+        // FIXME: Report something better
+        mem::size_of::<Self>() as size_t
+    }
+}
+
+impl SignalScheduler {
+    pub fn new(configuration: &Configuration) -> Self {
+        Self {
+            configuration: configuration.clone(),
+            profile: None,
         }
     }
 
@@ -217,95 +158,4 @@ impl SignalScheduler {
             thread::sleep(Duration::from_millis(500));
         });
     }
-
-    // Ruby Methods
-
-    pub unsafe extern "C" fn rb_initialize(
-        argc: c_int,
-        argv: *const VALUE,
-        rbself: VALUE,
-    ) -> VALUE {
-        let mut collector = unsafe { Self::get_struct_from(rbself) };
-        collector.initialize(argc, argv, rbself)
-    }
-
-    pub unsafe extern "C" fn rb_start(rbself: VALUE) -> VALUE {
-        let mut collector = unsafe { Self::get_struct_from(rbself) };
-        collector.start(rbself)
-    }
-
-    pub unsafe extern "C" fn rb_stop(rbself: VALUE) -> VALUE {
-        let mut collector = unsafe { Self::get_struct_from(rbself) };
-        collector.stop(rbself)
-    }
-
-    // Functions for TypedData
-
-    // Extract the SignalScheduler struct from a Ruby object
-    unsafe fn get_struct_from(obj: VALUE) -> ManuallyDrop<Box<Self>> {
-        unsafe {
-            let ptr = rb_check_typeddata(obj, &RBDATA);
-            ManuallyDrop::new(Box::from_raw(ptr as *mut SignalScheduler))
-        }
-    }
-
-    #[allow(non_snake_case)]
-    pub unsafe extern "C" fn rb_alloc(_rbself: VALUE) -> VALUE {
-        let collector = Box::new(SignalScheduler::new());
-        unsafe { Arc::increment_strong_count(&collector) };
-
-        unsafe {
-            let rb_mPf2: VALUE = rb_define_module(cstr!("Pf2"));
-            let rb_cSignalScheduler =
-                rb_define_class_under(rb_mPf2, cstr!("SignalScheduler"), rb_cObject);
-
-            // "Wrap" the SignalScheduler struct into a Ruby object
-            rb_data_typed_object_wrap(
-                rb_cSignalScheduler,
-                Box::into_raw(collector) as *mut c_void,
-                &RBDATA,
-            )
-        }
-    }
-
-    unsafe extern "C" fn dmark(ptr: *mut c_void) {
-        unsafe {
-            let collector = ManuallyDrop::new(Box::from_raw(ptr as *mut SignalScheduler));
-            if let Some(profile) = &collector.profile {
-                match profile.read() {
-                    Ok(profile) => {
-                        profile.dmark();
-                    }
-                    Err(_) => {
-                        panic!("[pf2 FATAL] dmark: Failed to acquire profile lock.");
-                    }
-                }
-            }
-        }
-    }
-
-    unsafe extern "C" fn dfree(ptr: *mut c_void) {
-        unsafe {
-            drop(Box::from_raw(ptr as *mut SignalScheduler));
-        }
-    }
-
-    unsafe extern "C" fn dsize(_: *const c_void) -> size_t {
-        // FIXME: Report something better
-        mem::size_of::<SignalScheduler>() as size_t
-    }
 }
-
-static mut RBDATA: rb_data_type_t = rb_data_type_t {
-    wrap_struct_name: cstr!("SignalScheduler"),
-    function: rb_data_type_struct__bindgen_ty_1 {
-        dmark: Some(SignalScheduler::dmark),
-        dfree: Some(SignalScheduler::dfree),
-        dsize: Some(SignalScheduler::dsize),
-        dcompact: None,
-        reserved: [null_mut(); 1],
-    },
-    parent: null_mut(),
-    data: null_mut(),
-    flags: 0,
-};

--- a/ext/pf2/src/signal_scheduler/timer_installer.rs
+++ b/ext/pf2/src/signal_scheduler/timer_installer.rs
@@ -8,9 +8,9 @@ use std::sync::{Mutex, RwLock};
 
 use rb_sys::*;
 
-use super::configuration::Configuration;
 use crate::profile::Profile;
 use crate::ruby_internal_apis::rb_thread_getcpuclockid;
+use crate::session::configuration::Configuration;
 use crate::signal_scheduler::{cstr, SignalHandlerArgs};
 
 #[derive(Debug)]
@@ -112,10 +112,10 @@ impl Inner {
         // Create and configure timer to fire every _interval_ ms of CPU time
         let mut timer: libc::timer_t = unsafe { mem::zeroed() };
         let clockid = match self.configuration.time_mode {
-            crate::signal_scheduler::TimeMode::CpuTime => unsafe {
+            crate::session::configuration::TimeMode::CpuTime => unsafe {
                 rb_thread_getcpuclockid(ruby_thread)
             },
-            crate::signal_scheduler::TimeMode::WallTime => libc::CLOCK_MONOTONIC,
+            crate::session::configuration::TimeMode::WallTime => libc::CLOCK_MONOTONIC,
         };
         let err = unsafe { libc::timer_create(clockid, &mut sigevent, &mut timer) };
         if err != 0 {

--- a/ext/pf2/src/timer_thread_scheduler.rs
+++ b/ext/pf2/src/timer_thread_scheduler.rs
@@ -1,8 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
-use std::ffi::{c_int, c_void, CStr, CString};
+use std::ffi::{c_void, CString};
 use std::mem::ManuallyDrop;
-use std::ptr::null_mut;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread;
@@ -13,112 +12,34 @@ use rb_sys::*;
 use crate::profile::Profile;
 use crate::profile_serializer::ProfileSerializer;
 use crate::sample::Sample;
+use crate::scheduler::Scheduler;
+use crate::session::configuration::Configuration;
 use crate::util::*;
 
 #[derive(Clone, Debug)]
 pub struct TimerThreadScheduler {
-    ruby_threads: Arc<RwLock<Vec<VALUE>>>,
-    interval: Option<Arc<Duration>>,
+    configuration: Arc<Configuration>,
     profile: Option<Arc<RwLock<Profile>>>,
     stop_requested: Arc<AtomicBool>,
 }
 
 #[derive(Debug)]
 struct PostponedJobArgs {
-    ruby_threads: Arc<RwLock<Vec<VALUE>>>,
+    configuration: Arc<Configuration>,
     profile: Arc<RwLock<Profile>>,
 }
 
-impl TimerThreadScheduler {
-    fn new() -> Self {
-        TimerThreadScheduler {
-            ruby_threads: Arc::new(RwLock::new(vec![])),
-            interval: None,
-            profile: None,
-            stop_requested: Arc::new(AtomicBool::new(false)),
-        }
-    }
-
-    fn initialize(&mut self, argc: c_int, argv: *const VALUE, _rbself: VALUE) -> VALUE {
-        // Parse arguments
-        let kwargs: VALUE = Qnil.into();
-        unsafe {
-            rb_scan_args(argc, argv, cstr!(":"), &kwargs);
-        };
-        let mut kwargs_values: [VALUE; 3] = [Qnil.into(); 3];
-        unsafe {
-            rb_get_kwargs(
-                kwargs,
-                [
-                    rb_intern(cstr!("interval_ms")),
-                    rb_intern(cstr!("threads")),
-                    rb_intern(cstr!("time_mode")),
-                ]
-                .as_mut_ptr(),
-                0,
-                3,
-                kwargs_values.as_mut_ptr(),
-            );
-        };
-        let interval: Duration = if kwargs_values[0] != Qundef as VALUE {
-            let interval_ms = unsafe { rb_num2long(kwargs_values[0]) };
-            Duration::from_millis(interval_ms.try_into().unwrap_or_else(|_| {
-                eprintln!(
-                    "[Pf2] Warning: Specified interval ({}) is not valid. Using default value (49ms).",
-                    interval_ms
-                );
-                49
-            }))
-        } else {
-            Duration::from_millis(49)
-        };
-        let threads: VALUE = if kwargs_values[1] != Qundef as VALUE {
-            kwargs_values[1]
-        } else {
-            unsafe { rb_funcall(rb_cThread, rb_intern(cstr!("list")), 0) }
-        };
-        if kwargs_values[2] != Qundef as VALUE {
-            let specified_mode = unsafe {
-                let mut str = rb_funcall(kwargs_values[2], rb_intern(cstr!("to_s")), 0);
-                let ptr = rb_string_value_ptr(&mut str);
-                CStr::from_ptr(ptr).to_str().unwrap()
-            };
-            if specified_mode != "wall" {
-                // Raise an ArgumentError
-                unsafe {
-                    rb_raise(
-                        rb_eArgError,
-                        cstr!("TimerThreadScheduler only supports :wall mode."),
-                    )
-                }
-            }
-        }
-
-        let mut target_ruby_threads = Vec::new();
-        unsafe {
-            for i in 0..RARRAY_LEN(threads) {
-                let ruby_thread: VALUE = rb_ary_entry(threads, i);
-                target_ruby_threads.push(ruby_thread);
-            }
-        }
-
-        self.interval = Some(Arc::new(interval));
-        self.ruby_threads = Arc::new(RwLock::new(target_ruby_threads.into_iter().collect()));
-
-        Qnil.into()
-    }
-
-    fn start(&mut self, _rbself: VALUE) -> VALUE {
+impl Scheduler for TimerThreadScheduler {
+    fn start(&mut self) -> VALUE {
         // Create Profile
         let profile = Arc::new(RwLock::new(Profile::new()));
         self.start_profile_buffer_flusher_thread(&profile);
+        self.profile = Some(profile);
 
-        // Start monitoring thread
-        let stop_requested = Arc::clone(&self.stop_requested);
-        let interval = Arc::clone(self.interval.as_ref().unwrap());
+        // Register the Postponed Job which does the actual work of collecting samples
         let postponed_job_args: Box<PostponedJobArgs> = Box::new(PostponedJobArgs {
-            ruby_threads: Arc::clone(&self.ruby_threads),
-            profile: Arc::clone(&profile),
+            configuration: Arc::clone(&self.configuration),
+            profile: Arc::clone(self.profile.as_ref().unwrap()),
         });
         let postponed_job_handle: rb_postponed_job_handle_t = unsafe {
             rb_postponed_job_preregister(
@@ -127,33 +48,18 @@ impl TimerThreadScheduler {
                 Box::into_raw(postponed_job_args) as *mut c_void, // FIXME: leak
             )
         };
-        thread::spawn(move || {
-            Self::thread_main_loop(stop_requested, interval, postponed_job_handle)
-        });
 
-        self.profile = Some(profile);
+        // Start a timer thread that periodically triggers postponed jobs based on configuration
+        let configuration = Arc::clone(&self.configuration);
+        let stop_requested = Arc::clone(&self.stop_requested);
+        thread::spawn(move || {
+            Self::thread_main_loop(configuration, stop_requested, postponed_job_handle)
+        });
 
         Qtrue.into()
     }
 
-    fn thread_main_loop(
-        stop_requested: Arc<AtomicBool>,
-        interval: Arc<Duration>,
-        postponed_job_handle: rb_postponed_job_handle_t,
-    ) {
-        loop {
-            if stop_requested.fetch_and(true, Ordering::Relaxed) {
-                break;
-            }
-            unsafe {
-                rb_postponed_job_trigger(postponed_job_handle);
-            }
-
-            thread::sleep(*interval);
-        }
-    }
-
-    fn stop(&self, _rbself: VALUE) -> VALUE {
+    fn stop(&mut self) -> VALUE {
         // Stop the collector thread
         self.stop_requested.store(true, Ordering::Relaxed);
 
@@ -180,6 +86,58 @@ impl TimerThreadScheduler {
         }
     }
 
+    fn dmark(&self) {
+        if let Some(profile) = &self.profile {
+            match profile.read() {
+                Ok(profile) => unsafe {
+                    profile.dmark();
+                },
+                Err(_) => {
+                    panic!("[pf2 FATAL] dmark: Failed to acquire profile lock.");
+                }
+            }
+        }
+    }
+
+    fn dfree(&self) {
+        // No-op
+    }
+
+    fn dsize(&self) -> size_t {
+        // FIXME: Report something better
+        std::mem::size_of::<TimerThreadScheduler>() as size_t
+    }
+}
+
+impl TimerThreadScheduler {
+    pub fn new(configuration: &Configuration) -> Self {
+        Self {
+            configuration: Arc::new(configuration.clone()),
+            profile: None,
+            stop_requested: Arc::new(AtomicBool::new(false)),
+        }
+
+        // cstr!("TimerThreadScheduler only supports :wall mode."),
+    }
+
+    fn thread_main_loop(
+        configuration: Arc<Configuration>,
+        stop_requested: Arc<AtomicBool>,
+        postponed_job_handle: rb_postponed_job_handle_t,
+    ) {
+        loop {
+            if stop_requested.fetch_and(true, Ordering::Relaxed) {
+                break;
+            }
+            unsafe {
+                log::trace!("Triggering postponed job");
+                rb_postponed_job_trigger(postponed_job_handle);
+            }
+
+            thread::sleep(configuration.interval);
+        }
+    }
+
     unsafe extern "C" fn postponed_job(ptr: *mut c_void) {
         unsafe {
             rb_gc_disable();
@@ -196,7 +154,7 @@ impl TimerThreadScheduler {
         };
 
         // Collect stack information from specified Ruby Threads
-        let ruby_threads = args.ruby_threads.try_read().unwrap();
+        let ruby_threads = &args.configuration.target_ruby_threads;
         for ruby_thread in ruby_threads.iter() {
             // Check if the thread is still alive
             if unsafe { rb_funcall(*ruby_thread, rb_intern(cstr!("status")), 0) } == Qfalse as u64 {
@@ -228,92 +186,4 @@ impl TimerThreadScheduler {
             thread::sleep(Duration::from_millis(500));
         });
     }
-
-    // Ruby Methods
-
-    pub unsafe extern "C" fn rb_initialize(
-        argc: c_int,
-        argv: *const VALUE,
-        rbself: VALUE,
-    ) -> VALUE {
-        let mut collector = Self::get_struct_from(rbself);
-        collector.initialize(argc, argv, rbself)
-    }
-
-    // SampleCollector.start
-    pub unsafe extern "C" fn rb_start(rbself: VALUE) -> VALUE {
-        let mut collector = Self::get_struct_from(rbself);
-        collector.start(rbself)
-    }
-
-    // SampleCollector.stop
-    pub unsafe extern "C" fn rb_stop(rbself: VALUE) -> VALUE {
-        let collector = Self::get_struct_from(rbself);
-        collector.stop(rbself)
-    }
-
-    // Functions for TypedData
-
-    fn get_struct_from(obj: VALUE) -> ManuallyDrop<Box<Self>> {
-        unsafe {
-            let ptr = rb_check_typeddata(obj, &RBDATA);
-            ManuallyDrop::new(Box::from_raw(ptr as *mut TimerThreadScheduler))
-        }
-    }
-
-    #[allow(non_snake_case)]
-    pub unsafe extern "C" fn rb_alloc(_rbself: VALUE) -> VALUE {
-        let collector = TimerThreadScheduler::new();
-
-        unsafe {
-            let rb_mPf2: VALUE = rb_define_module(cstr!("Pf2"));
-            let rb_cTimerThreadScheduler =
-                rb_define_class_under(rb_mPf2, cstr!("TimerThreadScheduler"), rb_cObject);
-
-            rb_data_typed_object_wrap(
-                rb_cTimerThreadScheduler,
-                Box::into_raw(Box::new(collector)) as *mut _ as *mut c_void,
-                &RBDATA,
-            )
-        }
-    }
-
-    unsafe extern "C" fn dmark(ptr: *mut c_void) {
-        unsafe {
-            let collector = ManuallyDrop::new(Box::from_raw(ptr as *mut TimerThreadScheduler));
-            if let Some(profile) = &collector.profile {
-                match profile.read() {
-                    Ok(profile) => {
-                        profile.dmark();
-                    }
-                    Err(_) => {
-                        panic!("[pf2 FATAL] dmark: Failed to acquire profile lock.");
-                    }
-                }
-            }
-        }
-    }
-    unsafe extern "C" fn dfree(ptr: *mut c_void) {
-        unsafe {
-            drop(Box::from_raw(ptr as *mut TimerThreadScheduler));
-        }
-    }
-    unsafe extern "C" fn dsize(_: *const c_void) -> size_t {
-        // FIXME: Report something better
-        std::mem::size_of::<TimerThreadScheduler>() as size_t
-    }
 }
-
-static mut RBDATA: rb_data_type_t = rb_data_type_t {
-    wrap_struct_name: cstr!("TimerThreadScheduler"),
-    function: rb_data_type_struct__bindgen_ty_1 {
-        dmark: Some(TimerThreadScheduler::dmark),
-        dfree: Some(TimerThreadScheduler::dfree),
-        dsize: Some(TimerThreadScheduler::dsize),
-        dcompact: None,
-        reserved: [null_mut(); 1],
-    },
-    parent: null_mut(),
-    data: null_mut(),
-    flags: 0,
-};

--- a/lib/pf2.rb
+++ b/lib/pf2.rb
@@ -1,30 +1,22 @@
 require_relative 'pf2/pf2'
+require_relative 'pf2/session'
 require_relative 'pf2/version'
 
 module Pf2
   class Error < StandardError; end
 
-  def self.default_scheduler_class
-    # SignalScheduler is Linux-only. Use TimerThreadScheduler on other platforms.
-    if defined?(SignalScheduler)
-      SignalScheduler
-    else
-      TimerThreadScheduler
-    end
-  end
-
   def self.start(...)
-    @@default_scheduler = default_scheduler_class.new(...)
-    @@default_scheduler.start
+    @@session = Pf2::Session.new(...)
+    @@session.start
   end
 
-  def self.stop(...)
-    @@default_scheduler.stop(...)
+  def self.stop
+    @@session.stop
   end
 
   def self.profile(&block)
     raise ArgumentError, "block required" unless block_given?
-    start([Thread.current], true)
+    start(threads: Thread.list)
     yield
     stop
   end

--- a/lib/pf2/session.rb
+++ b/lib/pf2/session.rb
@@ -1,0 +1,7 @@
+module Pf2
+  class Session
+    attr_reader :configuration
+
+    # Implementation is in Rust code.
+  end
+end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -1,0 +1,27 @@
+require 'minitest/autorun'
+
+require 'pf2'
+
+class SessionTest < Minitest::Test
+  def test_default_options
+    config = Pf2::Session.new.configuration
+    assert_equal(:signal, config[:scheduler])
+    assert_equal(49, config[:interval_ms])
+    assert_equal(:cpu, config[:time_mode])
+  end
+
+  def test_scheduler_option
+    config = Pf2::Session.new(scheduler: :timer_thread).configuration
+    assert_equal(:timer_thread, config[:scheduler])
+  end
+
+  def test_interval_ms_option
+    config = Pf2::Session.new(interval_ms: 1).configuration
+    assert_equal(1, config[:interval_ms])
+  end
+
+  def test_time_mode_option
+    config = Pf2::Session.new(time_mode: :wall).configuration
+    assert_equal(:wall, config[:time_mode])
+  end
+end


### PR DESCRIPTION
This patch introduces `Pf2::Session` which will serve as the main interaction layer from Ruby code. 

`SignalScheduler` and `TimerThreadScheduler` are now hidden from Ruby code. All configuration shall now be done through `Session`, and `Session` will take care of Schedulers.

## Usage

```rb
Pf2::Scheduler.new(scheduler: :signal)
```