### PR TITLE
Default to TimerThread scheduler on non-Linux platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Properly default to TimerThread scheduler on non-Linux environments.
+
 
 ## [0.5.1] - 2024-03-25
 

--- a/ext/pf2/src/session/configuration.rs
+++ b/ext/pf2/src/session/configuration.rs
@@ -6,9 +6,16 @@ use rb_sys::*;
 
 use crate::util::cstr;
 
+#[cfg(target_os = "linux")]
 pub const DEFAULT_SCHEDULER: Scheduler = Scheduler::Signal;
-pub const DEFAULT_INTERVAL: Duration = Duration::from_millis(49);
+#[cfg(target_os = "linux")]
 pub const DEFAULT_TIME_MODE: TimeMode = TimeMode::CpuTime;
+#[cfg(not(target_os = "linux"))]
+pub const DEFAULT_SCHEDULER: Scheduler = Scheduler::TimerThread;
+#[cfg(not(target_os = "linux"))]
+pub const DEFAULT_TIME_MODE: TimeMode = TimeMode::WallTime;
+
+pub const DEFAULT_INTERVAL: Duration = Duration::from_millis(49);
 
 #[derive(Clone, Debug)]
 pub struct Configuration {


### PR DESCRIPTION
Closes https://github.com/osyoyu/pf2/issues/20 .

On non-Linux platforms, the Signal scheduler is still not yet supported and will panic/crash. Pf2 should default to the TimerThread scheduler in such environments.