### PR TITLE
Change default sampling interval to 9 ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Changed
+
+- The default sampling interval is now 9 ms (was originally 49 ms).
+  - 9 (and 49) are chosen to avoid lockstep sampling.
+
+
 ## [0.5.2] - 2024-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Pf2 accepts the following configuration keys:
 
 ```rb
 Pf2.start(
-  interval_ms: 49,        # Integer: The sampling interval in milliseconds (default: 49)
+  interval_ms: 9,        # Integer: The sampling interval in milliseconds (default: 9)
   time_mode: :cpu,        # `:cpu` or `:wall`: The sampling timer's mode
                           # (default: `:cpu` for SignalScheduler, `:wall` for TimerThreadScheduler)
   threads: [th1, th2],    # `Array<Thread>` | `:all`: A list of Ruby Threads to be tracked.

--- a/ext/pf2/src/session.rs
+++ b/ext/pf2/src/session.rs
@@ -127,10 +127,10 @@ impl Session {
         let interval_ms = unsafe { rb_num2long(value) };
         Duration::from_millis(interval_ms.try_into().unwrap_or_else(|_| {
             eprintln!(
-                "[Pf2] Warning: Specified interval ({}) is not valid. Using default value (49ms).",
+                "[Pf2] Warning: Specified interval ({}) is not valid. Using default value (9ms).",
                 interval_ms
             );
-            49
+            9
         }))
     }
 

--- a/ext/pf2/src/session/configuration.rs
+++ b/ext/pf2/src/session/configuration.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_SCHEDULER: Scheduler = Scheduler::TimerThread;
 #[cfg(not(target_os = "linux"))]
 pub const DEFAULT_TIME_MODE: TimeMode = TimeMode::WallTime;
 
-pub const DEFAULT_INTERVAL: Duration = Duration::from_millis(49);
+pub const DEFAULT_INTERVAL: Duration = Duration::from_millis(9);
 
 #[derive(Clone, Debug)]
 pub struct Configuration {

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -6,7 +6,7 @@ class SessionTest < Minitest::Test
   def test_default_options
     config = Pf2::Session.new.configuration
     assert_equal(:signal, config[:scheduler])
-    assert_equal(49, config[:interval_ms])
+    assert_equal(9, config[:interval_ms])
     assert_equal(:cpu, config[:time_mode])
   end
 


### PR DESCRIPTION
5 times more samples by default!

Additional overhead should be ok, but users can switch back by passing `interval_ms: 49` to `Pf2::Session.new`.