### PR TITLE
Rewrite serializer and introduce new serialization format (experimental)

### DIFF
--- a/ext/pf2/src/lib.rs
+++ b/ext/pf2/src/lib.rs
@@ -10,6 +10,7 @@ mod profile_serializer;
 mod ringbuffer;
 mod sample;
 mod scheduler;
+mod serialization;
 mod session;
 #[cfg(target_os = "linux")]
 mod signal_scheduler;

--- a/ext/pf2/src/profile.rs
+++ b/ext/pf2/src/profile.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 use std::{collections::HashSet, ptr::null_mut};
 
 use rb_sys::*;
@@ -15,7 +15,9 @@ const DEFAULT_RINGBUFFER_CAPACITY: usize = 320;
 
 #[derive(Debug)]
 pub struct Profile {
-    pub start_timestamp: Instant,
+    pub start_timestamp: SystemTime,
+    pub start_instant: Instant,
+    pub end_instant: Option<Instant>,
     pub samples: Vec<Sample>,
     pub temporary_sample_buffer: Ringbuffer,
     pub backtrace_state: BacktraceState,
@@ -35,7 +37,9 @@ impl Profile {
         };
 
         Self {
-            start_timestamp: Instant::now(),
+            start_timestamp: SystemTime::now(),
+            start_instant: Instant::now(),
+            end_instant: None,
             samples: vec![],
             temporary_sample_buffer: Ringbuffer::new(DEFAULT_RINGBUFFER_CAPACITY),
             backtrace_state,

--- a/ext/pf2/src/profile_serializer.rs
+++ b/ext/pf2/src/profile_serializer.rs
@@ -221,7 +221,7 @@ impl ProfileSerializer {
 
                     if merged_stack.is_empty() {
                         // This is the leaf node, record a Sample
-                        let elapsed_ns = (sample.timestamp - profile.start_timestamp).as_nanos();
+                        let elapsed_ns = (sample.timestamp - profile.start_instant).as_nanos();
                         thread_serializer.samples.push(ProfileSample {
                             elapsed_ns,
                             stack_tree_id: stack_tree.node_id,

--- a/ext/pf2/src/serialization.rs
+++ b/ext/pf2/src/serialization.rs
@@ -1,0 +1,2 @@
+pub mod profile;
+pub mod serializer;

--- a/ext/pf2/src/serialization/profile.rs
+++ b/ext/pf2/src/serialization/profile.rs
@@ -1,0 +1,46 @@
+#[derive(Clone, Deserialize, Serialize)]
+pub struct Profile {
+    pub samples: Vec<Sample>,
+    pub locations: Vec<Location>,
+    pub functions: Vec<Function>,
+    pub start_timestamp_ns: u128,
+    pub duration_ns: u128,
+}
+
+pub type LocationIndex = usize;
+pub type FunctionIndex = usize;
+
+/// Sample
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Sample {
+    /// The stack leading to this sample.
+    /// The leaf node will be stored at `stack[0]`.
+    pub stack: Vec<LocationIndex>,
+    pub ruby_thread_id: Option<u64>,
+}
+
+/// Location represents a location (line) in the source code when a sample was captured.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct Location {
+    pub function_index: FunctionIndex,
+    pub lineno: i32,
+    pub address: Option<usize>,
+}
+
+/// Function represents a Ruby method or a C function in the profile.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct Function {
+    pub implementation: FunctionImplementation,
+    pub name: Option<String>, // unique key
+    pub filename: Option<String>,
+    /// The first line number in the method/function definition.
+    /// For the actual location (line) which was hit during sample capture, refer to `Location.lineno`.
+    pub start_lineno: Option<i32>,
+    pub start_address: Option<usize>,
+}
+
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub enum FunctionImplementation {
+    Ruby,
+    C,
+}

--- a/ext/pf2/src/serialization/serializer.rs
+++ b/ext/pf2/src/serialization/serializer.rs
@@ -1,0 +1,134 @@
+use std::ffi::CStr;
+
+use rb_sys::*;
+
+use super::profile::{Function, FunctionImplementation, Location, LocationIndex, Profile, Sample};
+use crate::util::RTEST;
+
+pub struct ProfileSerializer2 {
+    profile: Profile,
+}
+
+impl ProfileSerializer2 {
+    pub fn new() -> ProfileSerializer2 {
+        ProfileSerializer2 {
+            profile: Profile {
+                start_timestamp_ns: 0,
+                duration_ns: 0,
+                samples: vec![],
+                locations: vec![],
+                functions: vec![],
+            },
+        }
+    }
+
+    pub fn serialize(&mut self, source: &crate::profile::Profile) -> String {
+        // Create a Sample for each sample collected
+        for sample in source.samples.iter() {
+            let mut stack: Vec<LocationIndex> = vec![];
+
+            // Iterate over the Ruby stack
+            let ruby_stack_depth = sample.line_count;
+            for i in 0..ruby_stack_depth {
+                let frame: VALUE = sample.frames[i as usize];
+                let lineno: i32 = sample.linenos[i as usize];
+
+                // Get the Location corresponding to the frame.
+                let location_index = self.process_ruby_frame(frame, lineno);
+
+                stack.push(location_index);
+            }
+
+            self.profile.samples.push(Sample {
+                stack,
+                ruby_thread_id: Some(sample.ruby_thread),
+            });
+        }
+
+        serde_json::to_string(&self.profile).unwrap()
+    }
+
+    /// Process a collected Ruby frame.
+    /// Calling this method will modify `self.profile` in place.
+    ///
+    /// Returns the index of the location in `locations`.
+    fn process_ruby_frame(&mut self, frame: VALUE, lineno: i32) -> LocationIndex {
+        // Build a Function corresponding to the frame, and get the index in `functions`
+        let function = Self::extract_function_from_frame(frame);
+        let function_index = match self
+            .profile
+            .functions
+            .iter_mut()
+            .position(|f| *f == function)
+        {
+            Some(index) => index,
+            None => {
+                self.profile.functions.push(function);
+                self.profile.functions.len() - 1
+            }
+        };
+
+        // Build a Location based on (1) the Function and (2) the actual line hit during sampling.
+        let location = Location {
+            function_index,
+            lineno,
+            address: None,
+        };
+        // Get the index of the location in `locations`
+        match self
+            .profile
+            .locations
+            .iter_mut()
+            .position(|l| *l == location)
+        {
+            Some(index) => index,
+            None => {
+                self.profile.locations.push(location);
+                self.profile.locations.len() - 1
+            }
+        }
+    }
+
+    fn extract_function_from_frame(frame: VALUE) -> Function {
+        unsafe {
+            let mut frame_full_label: VALUE = rb_profile_frame_full_label(frame);
+            let frame_full_label: Option<String> = if RTEST(frame_full_label) {
+                Some(
+                    CStr::from_ptr(rb_string_value_cstr(&mut frame_full_label))
+                        .to_str()
+                        .unwrap()
+                        .to_owned(),
+                )
+            } else {
+                None
+            };
+
+            let mut frame_path: VALUE = rb_profile_frame_path(frame);
+            let frame_path: Option<String> = if RTEST(frame_path) {
+                Some(
+                    CStr::from_ptr(rb_string_value_cstr(&mut frame_path))
+                        .to_str()
+                        .unwrap()
+                        .to_owned(),
+                )
+            } else {
+                None
+            };
+
+            let frame_first_lineno: VALUE = rb_profile_frame_first_lineno(frame);
+            let frame_first_lineno: Option<i32> = if RTEST(frame_first_lineno) {
+                Some(rb_num2int(frame_first_lineno).try_into().unwrap())
+            } else {
+                None
+            };
+
+            Function {
+                implementation: FunctionImplementation::Ruby,
+                name: frame_full_label,
+                filename: frame_path,
+                start_lineno: frame_first_lineno,
+                start_address: None,
+            }
+        }
+    }
+}

--- a/ext/pf2/src/serialization/serializer.rs
+++ b/ext/pf2/src/serialization/serializer.rs
@@ -23,6 +23,18 @@ impl ProfileSerializer2 {
     }
 
     pub fn serialize(&mut self, source: &crate::profile::Profile) -> String {
+        // Fill in meta fields
+        self.profile.start_timestamp_ns = source
+            .start_timestamp
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        self.profile.duration_ns = source
+            .end_instant
+            .unwrap()
+            .duration_since(source.start_instant)
+            .as_nanos();
+
         // Create a Sample for each sample collected
         for sample in source.samples.iter() {
             let mut stack: Vec<LocationIndex> = vec![];

--- a/ext/pf2/src/session/configuration.rs
+++ b/ext/pf2/src/session/configuration.rs
@@ -23,6 +23,7 @@ pub struct Configuration {
     pub interval: Duration,
     pub time_mode: TimeMode,
     pub target_ruby_threads: Threads,
+    pub use_experimental_serializer: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/ext/pf2/src/signal_scheduler.rs
+++ b/ext/pf2/src/signal_scheduler.rs
@@ -46,6 +46,7 @@ impl Scheduler for SignalScheduler {
         match self.profile.try_write() {
             Ok(mut profile) => {
                 profile.flush_temporary_sample_buffer();
+                profile.end_instant = Some(std::time::Instant::now());
             }
             Err(_) => {
                 println!("[pf2 ERROR] stop: Failed to acquire profile lock.");

--- a/ext/pf2/src/signal_scheduler.rs
+++ b/ext/pf2/src/signal_scheduler.rs
@@ -5,6 +5,7 @@ use crate::profile_serializer::ProfileSerializer;
 use crate::ruby_internal_apis::rb_thread_getcpuclockid;
 use crate::sample::Sample;
 use crate::scheduler::Scheduler;
+use crate::serialization::serializer::ProfileSerializer2;
 use crate::session::configuration::{self, Configuration};
 
 use core::panic;
@@ -57,7 +58,11 @@ impl Scheduler for SignalScheduler {
         let profile = self.profile.try_read().unwrap();
         log::debug!("Number of samples: {}", profile.samples.len());
 
-        let serialized = ProfileSerializer::serialize(&profile);
+        let serialized = if self.configuration.use_experimental_serializer {
+            ProfileSerializer2::new().serialize(&profile)
+        } else {
+            ProfileSerializer::serialize(&profile)
+        };
         let serialized = CString::new(serialized).unwrap();
         unsafe { rb_str_new_cstr(serialized.as_ptr()) }
     }

--- a/ext/pf2/src/timer_thread_scheduler.rs
+++ b/ext/pf2/src/timer_thread_scheduler.rs
@@ -12,6 +12,7 @@ use crate::profile::Profile;
 use crate::profile_serializer::ProfileSerializer;
 use crate::sample::Sample;
 use crate::scheduler::Scheduler;
+use crate::serialization::serializer::ProfileSerializer2;
 use crate::session::configuration::{self, Configuration};
 use crate::util::*;
 
@@ -72,7 +73,11 @@ impl Scheduler for TimerThreadScheduler {
         let profile = self.profile.try_read().unwrap();
         log::debug!("Number of samples: {}", profile.samples.len());
 
-        let serialized = ProfileSerializer::serialize(&profile);
+        let serialized = if self.configuration.use_experimental_serializer {
+            ProfileSerializer2::new().serialize(&profile)
+        } else {
+            ProfileSerializer::serialize(&profile)
+        };
         let serialized = CString::new(serialized).unwrap();
         unsafe { rb_str_new_cstr(serialized.as_ptr()) }
     }

--- a/ext/pf2/src/timer_thread_scheduler.rs
+++ b/ext/pf2/src/timer_thread_scheduler.rs
@@ -61,6 +61,7 @@ impl Scheduler for TimerThreadScheduler {
         match self.profile.try_write() {
             Ok(mut profile) => {
                 profile.flush_temporary_sample_buffer();
+                profile.end_instant = Some(std::time::Instant::now());
             }
             Err(_) => {
                 println!("[pf2 ERROR] stop: Failed to acquire profile lock.");


### PR DESCRIPTION
This patch introduces a new serialization format for `pf2profile` files, and adds a new serializer.

## Motivation

The original serialization format had some problems:

- The stack tree was represented as a nested JSON object. In applications where deep stacks appear (e.g. Rails), the nesting went too deep to the point that some JSON parsers refused to accept (including Ruby's `JSON`). Workarounds were available (`max_nesting: false`), but it wasn't human-friendly anyway.
- The profile was segmented by Thread ids. This was because I loosely followed [Firefox Profiler's format](https://github.com/firefox-devtools/profiler/blob/e680dc668f937457afbf08eeed6ec2675298d22b/docs-developer/processed-profile-format.md) when designing pf2profile structure, but this wasn't the most efficient way.
- The serializer was a whole mess 🙃 

## New structure

The new profile format is based on arrays and indices into arrays. See ext/pf2/src/profile.rs for the details.

## Migration plan

The new format/serializer still does not fully support all Pf2 features (namely Native Stack Consolidation) and further consideration must be done. Until everything is ported, Pf2 will emit the new structure only when `use_experimental_serializer: true` is passed.