### PR TITLE
(Re)implement StackWeaver

### DIFF
--- a/lib/pf2/reporter.rb
+++ b/lib/pf2/reporter.rb
@@ -1,5 +1,2 @@
+require_relative './reporter/stack_weaver'
 require_relative './reporter/firefox_profiler'
-
-module Pf2
-  module Reporter; end
-end

--- a/lib/pf2/reporter/stack_weaver.rb
+++ b/lib/pf2/reporter/stack_weaver.rb
@@ -1,0 +1,79 @@
+module Pf2
+  module Reporter
+    class StackWeaver
+      def initialize(profile)
+        @profile = profile
+      end
+
+      def weave(ruby_stack, native_stack)
+        ruby_stack = ruby_stack.dup
+        native_stack = native_stack.dup
+
+        weaved_stack = []
+
+        current_stack = :native
+        loop do
+          break if ruby_stack.size == 0 && native_stack.size == 0
+          case current_stack
+          when :ruby
+            if ruby_stack.size == 0 # We've reached the end of the Ruby stack
+              current_stack = :native
+              next
+            end
+
+            location_index = ruby_stack.pop
+            weaved_stack.unshift(location_index)
+
+            current_stack = :native if should_switch_to_native?(location_index, native_stack.dup)
+
+          when :native
+            if native_stack.size == 0 # We've reached the end of the native stack
+              current_stack = :ruby
+              next
+            end
+
+            location_index = native_stack.pop
+            weaved_stack.unshift(location_index)
+
+            current_stack = :ruby if should_switch_to_ruby?(location_index)
+          end
+        end
+
+        weaved_stack
+      end
+
+      # @param [Integer] location_index
+      # @param [Array<Integer>] native_stack_remainder
+      def should_switch_to_native?(location_index, native_stack_remainder)
+        location = @profile[:locations][location_index]
+        function = @profile[:functions][location[:function_index]]
+        raise if function[:implementation] != :ruby # assert
+
+        # Is the current Ruby function a cfunc?
+        return false if function[:start_address] == nil
+
+        # Does a corresponding native function exist in the remainder of the native stack?
+        loop do
+          break if native_stack_remainder.size == 0
+          n_location_index = native_stack_remainder.pop
+          n_location = @profile[:locations][n_location_index]
+          n_function = @profile[:functions][n_location[:function_index]]
+
+          return true if function[:start_address] == n_function[:start_address]
+        end
+
+        false
+      end
+
+      def should_switch_to_ruby?(location_index)
+        location = @profile[:locations][location_index]
+        function = @profile[:functions][location[:function_index]]
+        raise if function[:implementation] != :native # assert
+
+        # If the next function is a vm_exec_core() (= VM_EXEC in vm_exec.h),
+        # we switch to the Ruby stack.
+        function[:name] == 'vm_exec_core'
+      end
+    end
+  end
+end

--- a/test/reporter/stack_weaver_test.rb
+++ b/test/reporter/stack_weaver_test.rb
@@ -1,0 +1,88 @@
+require 'minitest/autorun'
+
+require 'pf2'
+require 'pf2/reporter'
+
+class StackWeaverTest < Minitest::Test
+  def test_ruby_only
+    profile = {
+      start_timestamp_ns: 1,
+      duration_ns: 1,
+      samples: [
+        { stack: [1, 0, 0], native_stack: [], ruby_thread_id: 1 }
+      ],
+      locations: [
+        { function_index: 0, lineno: 1, address: nil },
+        { function_index: 1, lineno: 1, address: nil },
+      ],
+      functions: [
+        { implementation: :ruby, name: "one", filename: nil, start_lineno: 1, start_address: nil },
+        { implementation: :ruby, name: "two", filename: nil, start_lineno: 2, start_address: nil },
+      ],
+    }
+    stack_weaver = Pf2::Reporter::StackWeaver.new(profile)
+
+    assert_equal(
+      [0, 0, 1].reverse,
+      stack_weaver.weave(profile[:samples][0][:stack], profile[:samples][0][:native_stack])
+    )
+  end
+
+  def test_both
+    profile = {
+      start_timestamp_ns: 1,
+      duration_ns: 1,
+      samples: [
+        { stack: [1, 0], native_stack: [3, 2], ruby_thread_id: 1 }
+      ],
+      locations: [
+        { function_index: 0, lineno: 1, address: nil },
+        { function_index: 1, lineno: 1, address: nil },
+        { function_index: 2, lineno: 1, address: nil },
+        { function_index: 3, lineno: 1, address: nil },
+      ],
+      functions: [
+        { implementation: :ruby, name: "<main>", filename: nil, start_lineno: 1, start_address: nil },
+        { implementation: :ruby, name: "pure_ruby", filename: nil, start_lineno: 2, start_address: 123 },
+        { implementation: :native, name: "main", filename: nil, start_lineno: 1, start_address: nil },
+        { implementation: :native, name: "vm_exec_core", filename: nil, start_lineno: 1, start_address: nil },
+      ],
+    }
+    stack_weaver = Pf2::Reporter::StackWeaver.new(profile)
+
+    assert_equal(
+      [2, 3, 0, 1].reverse,
+      stack_weaver.weave(profile[:samples][0][:stack], profile[:samples][0][:native_stack])
+    )
+  end
+
+  def test_cfunc
+    profile = {
+      start_timestamp_ns: 1,
+      duration_ns: 1,
+      samples: [
+        { stack: [1, 0], native_stack: [4, 3, 2], ruby_thread_id: 1 }
+      ],
+      locations: [
+        { function_index: 0, lineno: 1, address: nil },
+        { function_index: 1, lineno: 1, address: nil },
+        { function_index: 2, lineno: 1, address: nil },
+        { function_index: 3, lineno: 1, address: nil },
+        { function_index: 4, lineno: 1, address: nil },
+      ],
+      functions: [
+        { implementation: :ruby, name: "<main>", filename: nil, start_lineno: 1, start_address: nil },
+        { implementation: :ruby, name: "cfunc", filename: nil, start_lineno: 2, start_address: 123 },
+        { implementation: :native, name: "main", filename: nil, start_lineno: 1, start_address: nil },
+        { implementation: :native, name: "vm_exec_core", filename: nil, start_lineno: 1, start_address: nil },
+        { implementation: :native, name: "native", filename: nil, start_lineno: 1, start_address: 123 },
+      ],
+    }
+    stack_weaver = Pf2::Reporter::StackWeaver.new(profile)
+
+    assert_equal(
+      [2, 3, 0, 1, 4].reverse,
+      stack_weaver.weave(profile[:samples][0][:stack], profile[:samples][0][:native_stack])
+    )
+  end
+end


### PR DESCRIPTION
- https://github.com/osyoyu/pf2/issues/29

This patch implements Ruby/Native stack weaving for Ser2. The rules/algorithm should not be changed from the current implementation in `Pf2::Reporter::FirefoxProfiler`.

https://github.com/osyoyu/pf2/blob/f75d3d052b73693230383c0e24320a65b40f14ed/lib/pf2/reporter/firefox_profiler.rb#L209