### PR TITLE
fix: Return profile result from Pf2.profile

### DIFF
--- a/lib/pf2.rb
+++ b/lib/pf2.rb
@@ -18,7 +18,8 @@ module Pf2
     raise ArgumentError, "block required" unless block_given?
     start(threads: Thread.list)
     yield
-    stop
+    result = stop
     @@session = nil # let GC clean up the session
+    result
   end
 end


### PR DESCRIPTION
95b2edb8918c0197e0f4ae44829532f35d5c064c broke the return value of Pf2.profile, which is cited as an example in the README.md.