### PR TITLE
libbacktrace for Pf2c

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/libbacktrace"]
+	path = vendor/libbacktrace
+	url = git@github.com:ianlancetaylor/libbacktrace.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     pf2 (0.8.0)
+      mini_portile2
       rake-compiler
       rb_sys (= 0.9.105)
       webrick
@@ -15,6 +16,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    mini_portile2 (2.8.8)
     minitest (5.21.2)
     pp (0.6.2)
       prettyprint

--- a/ext/pf2c/backtrace_state.h
+++ b/ext/pf2c/backtrace_state.h
@@ -1,0 +1,14 @@
+#ifndef PF2_BACKTRACE_H
+#define PF2_BACKTRACE_H
+
+#include <backtrace.h>
+
+struct backtrace_state *global_backtrace_state = NULL;
+
+void
+pf2_backtrace_print_error(void *data, const char *msg, int errnum)
+{
+  printf("libbacktrace error callback: %s (errnum %d)\n", msg, errnum);
+}
+
+#endif // PF2_BACKTRACE_H

--- a/ext/pf2c/extconf.rb
+++ b/ext/pf2c/extconf.rb
@@ -1,4 +1,15 @@
 require 'mkmf'
+require 'mini_portile2'
+
+libbacktrace = MiniPortile.new('libbacktrace', '1.0.0')
+libbacktrace.source_directory = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'vendor', 'libbacktrace'))
+libbacktrace.configure_options << 'CFLAGS=-fPIC'
+libbacktrace.cook
+libbacktrace.mkmf_config
+
+if !have_func('backtrace_full', 'backtrace.h')
+  raise 'libbacktrace has not been properly configured'
+end
 
 append_cflags('-fvisibility=hidden')
 append_cflags('-DPF2_DEBUG') # TODO: make this conditional

--- a/ext/pf2c/session.c
+++ b/ext/pf2c/session.c
@@ -10,6 +10,7 @@
 #include <ruby.h>
 #include <ruby/debug.h>
 
+#include "backtrace_state.h"
 #include "sample.h"
 #include "session.h"
 #include "serializer.h"
@@ -209,6 +210,14 @@ rb_pf2_session_stop(VALUE self)
 VALUE
 pf2_session_alloc(VALUE self)
 {
+    // Initialize state for libbacktrace
+    if (global_backtrace_state == NULL) {
+        global_backtrace_state = backtrace_create_state("pf2", 1, pf2_backtrace_print_error, NULL);
+        if (global_backtrace_state == NULL) {
+            rb_raise(rb_eRuntimeError, "Failed to initialize libbacktrace");
+        }
+    }
+
     struct pf2_session *session = malloc(sizeof(struct pf2_session));
     if (session == NULL) {
         rb_raise(rb_eNoMemError, "Failed to allocate memory");

--- a/pf2.gemspec
+++ b/pf2.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(__dir__) do
-    `git ls-files -z`.split("\x0").reject do |f|
+    `git ls-files -z --recurse-submodules`.split("\x0").reject do |f|
       (File.expand_path(f) == __FILE__) ||
         f.start_with?(*%w[bin/ test/ spec/ .git Gemfile])
     end
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rake-compiler'
+  spec.add_dependency 'mini_portile2'
   spec.add_dependency 'rb_sys', '0.9.105'
   spec.add_dependency 'webrick'
 


### PR DESCRIPTION
This patch links libbacktrace (https://github.com/ianlancetaylor/libbacktrace) to the pf2c library.

For the Rust version, I have vendored the entire libbacktrace library and wrapped it in a crate. This time, I have opted to use GIt submodules and build it via mini_portile2. There should be no fundamental differences other from those.