### PR TITLE
Capture native stack in Pf2c

### DIFF
--- a/ext/pf2c/backtrace_state.c
+++ b/ext/pf2c/backtrace_state.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include "backtrace_state.h"
+
+struct backtrace_state *global_backtrace_state = NULL;
+
+void
+pf2_backtrace_print_error(void *data, const char *msg, int errnum)
+{
+    printf("libbacktrace error callback: %s (errnum %d)\n", msg, errnum);
+}

--- a/ext/pf2c/backtrace_state.h
+++ b/ext/pf2c/backtrace_state.h
@@ -3,12 +3,8 @@
 
 #include <backtrace.h>
 
-struct backtrace_state *global_backtrace_state = NULL;
+extern struct backtrace_state *global_backtrace_state;
 
-void
-pf2_backtrace_print_error(void *data, const char *msg, int errnum)
-{
-  printf("libbacktrace error callback: %s (errnum %d)\n", msg, errnum);
-}
+void pf2_backtrace_print_error(void *data, const char *msg, int errnum);
 
 #endif // PF2_BACKTRACE_H

--- a/ext/pf2c/sample.c
+++ b/ext/pf2c/sample.c
@@ -1,10 +1,17 @@
 #include <stdbool.h>
 #include <time.h>
 
+#include <backtrace.h>
 #include <ruby.h>
 #include <ruby/debug.h>
 
+#include "backtrace_state.h"
 #include "sample.h"
+
+const int PF2_SAMPLE_MAX_NATIVE_DEPTH = 300;
+
+static int capture_native_backtrace(struct pf2_sample *sample);
+static int backtrace_on_ok(void *data, uintptr_t pc);
 
 // Capture a sample from the current thread.
 bool
@@ -18,5 +25,46 @@ pf2_sample_capture(struct pf2_sample *sample)
     // Obtain the current stack from Ruby
     sample->depth = rb_profile_frames(0, 200, sample->cmes, sample->linenos);
 
+    // Capture C-level backtrace
+    sample->native_stack_depth = capture_native_backtrace(sample);
+
     return true;
+}
+
+// Struct to be passed to backtrace_on_ok
+struct bt_data {
+    struct pf2_sample *pf2_sample;
+    int index;
+};
+
+static int
+capture_native_backtrace(struct pf2_sample *sample)
+{
+    struct backtrace_state *state = global_backtrace_state;
+    assert(state != NULL);
+
+    struct bt_data data;
+    data.pf2_sample = sample;
+    data.index = 0;
+
+    // Capture the current PC
+    // Skip the first 2 frames (capture_native_backtrace, sigprof_handler)
+    backtrace_simple(state, 2, backtrace_on_ok, pf2_backtrace_print_error, &data);
+
+    return data.index;
+}
+
+static int
+backtrace_on_ok(void *data, uintptr_t pc)
+{
+    struct bt_data *bt_data = (struct bt_data *)data;
+    struct pf2_sample *sample = bt_data->pf2_sample;
+
+    // Store the PC value
+    if (bt_data->index < PF2_SAMPLE_MAX_NATIVE_DEPTH) {
+        sample->native_stack[bt_data->index] = pc;
+        bt_data->index++;
+    }
+
+    return 0; // Continue backtrace
 }

--- a/ext/pf2c/sample.h
+++ b/ext/pf2c/sample.h
@@ -3,10 +3,16 @@
 
 #include <ruby.h>
 
+extern const int PF2_SAMPLE_MAX_NATIVE_DEPTH;
+
 struct pf2_sample {
     int depth;
     VALUE cmes[200];
     int linenos[200];
+
+    size_t native_stack_depth;
+    uintptr_t native_stack[200];
+
     uint64_t consumed_time_ns;
     uint64_t timestamp_ns;
 };

--- a/ext/pf2c/serializer.h
+++ b/ext/pf2c/serializer.h
@@ -6,23 +6,23 @@
 #include "session.h"
 
 struct pf2_ser_sample {
-    size_t *stack;
+    int *stack;
     size_t stack_count;
-    size_t *native_stack;
+    int *native_stack;
     size_t native_stack_count;
     size_t ruby_thread_id;
     uint64_t elapsed_ns;
 };
 
 struct pf2_ser_location {
-    size_t function_index;
+    int function_index;
     int32_t lineno;
     size_t address;
 };
 
 enum function_implementation {
     IMPLEMENTATION_RUBY,
-    // IMPLEMENTATION_NATIVE
+    IMPLEMENTATION_NATIVE
 };
 
 struct pf2_ser_function {


### PR DESCRIPTION
Capture native stack frames (the current PC to be more specific) when the sample capture process runs.

This implementation uses libbacktrace as its backend, which is the same as the Rust implementation.

There should be no problems calling backtrace_simple() in the signal handler as it is marked as async-signal-safe. The first 2 frames will be skipped (not included in the capture) since they will always be capture_native_backtrace() and sigprof_handler().