### PR TITLE
Configuration interface for Pf2c

### DIFF
--- a/ext/pf2c/configuration.c
+++ b/ext/pf2c/configuration.c
@@ -1,0 +1,90 @@
+#include <ruby.h>
+#include <stdlib.h>
+
+#include "configuration.h"
+
+static int extract_interval_ms(VALUE options_hash);
+static enum pf2_time_mode extract_time_mode(VALUE options_hash);
+
+struct pf2_configuration *
+pf2_configuration_new_from_options_hash(VALUE options_hash)
+{
+    struct pf2_configuration *config = malloc(sizeof(struct pf2_configuration));
+    if (!config) {
+        rb_raise(rb_eRuntimeError, "Failed to allocate configuration");
+    }
+
+    config->interval_ms = extract_interval_ms(options_hash);
+    config->time_mode = extract_time_mode(options_hash);
+
+    return config;
+}
+
+static int
+extract_interval_ms(VALUE options_hash)
+{
+    if (options_hash == Qnil) {
+        return PF2_DEFAULT_INTERVAL_MS;
+    }
+
+    VALUE interval_ms = rb_hash_aref(options_hash, ID2SYM(rb_intern("interval_ms")));
+    if (interval_ms == Qundef || interval_ms == Qnil) {
+        return PF2_DEFAULT_INTERVAL_MS;
+    }
+
+    return NUM2INT(interval_ms);
+}
+
+static enum pf2_time_mode
+extract_time_mode(VALUE options_hash)
+{
+    if (options_hash == Qnil) {
+        return PF2_DEFAULT_TIME_MODE;
+    }
+
+    VALUE time_mode = rb_hash_aref(options_hash, ID2SYM(rb_intern("time_mode")));
+    if (time_mode == Qundef || time_mode == Qnil) {
+        return PF2_DEFAULT_TIME_MODE;
+    }
+
+    if (time_mode == ID2SYM(rb_intern("cpu"))) {
+        return PF2_TIME_MODE_CPU_TIME;
+    } else if (time_mode == ID2SYM(rb_intern("wall"))) {
+        return PF2_TIME_MODE_WALL_TIME;
+    } else {
+        VALUE time_mode_str = rb_obj_as_string(time_mode);
+        rb_raise(rb_eArgError, "Invalid time mode: %s", StringValueCStr(time_mode_str));
+    }
+}
+
+void
+pf2_configuration_free(struct pf2_configuration *config)
+{
+    free(config);
+}
+
+VALUE
+pf2_configuration_to_ruby_hash(struct pf2_configuration *config)
+{
+    VALUE hash = rb_hash_new();
+
+    // interval_ms
+    rb_hash_aset(hash, ID2SYM(rb_intern("interval_ms")), INT2NUM(config->interval_ms));
+
+    // time_mode
+    VALUE time_mode_sym;
+    switch (config->time_mode) {
+    case PF2_TIME_MODE_CPU_TIME:
+        time_mode_sym = ID2SYM(rb_intern("cpu"));
+        break;
+    case PF2_TIME_MODE_WALL_TIME:
+        time_mode_sym = ID2SYM(rb_intern("wall"));
+        break;
+    default:
+        rb_raise(rb_eRuntimeError, "Invalid time mode");
+        break;
+    }
+    rb_hash_aset(hash, ID2SYM(rb_intern("time_mode")), time_mode_sym);
+
+    return hash;
+}

--- a/ext/pf2c/configuration.h
+++ b/ext/pf2c/configuration.h
@@ -1,0 +1,23 @@
+#ifndef PF2_CONFIGURATION_H
+#define PF2_CONFIGURATION_H
+
+#include <ruby.h>
+
+enum pf2_time_mode {
+    PF2_TIME_MODE_CPU_TIME,
+    PF2_TIME_MODE_WALL_TIME,
+};
+
+struct pf2_configuration {
+    int interval_ms;
+    enum pf2_time_mode time_mode;
+};
+
+#define PF2_DEFAULT_INTERVAL_MS 9
+#define PF2_DEFAULT_TIME_MODE PF2_TIME_MODE_CPU_TIME
+
+struct pf2_configuration *pf2_configuration_new_from_options_hash(VALUE options_hash);
+void pf2_configuration_free(struct pf2_configuration *config);
+VALUE pf2_configuration_to_ruby_hash(struct pf2_configuration *config);
+
+#endif // PF2_CONFIGURATION_H

--- a/ext/pf2c/pf2.c
+++ b/ext/pf2c/pf2.c
@@ -10,6 +10,8 @@ Init_pf2(void)
     rb_mPf2c = rb_define_module("Pf2c");
     VALUE rb_mPf2c_cSession = rb_define_class_under(rb_mPf2c, "Session", rb_cObject);
     rb_define_alloc_func(rb_mPf2c_cSession, pf2_session_alloc);
+    rb_define_method(rb_mPf2c_cSession, "initialize", rb_pf2_session_initialize, -1);
     rb_define_method(rb_mPf2c_cSession, "start", rb_pf2_session_start, 0);
     rb_define_method(rb_mPf2c_cSession, "stop", rb_pf2_session_stop, 0);
+    rb_define_method(rb_mPf2c_cSession, "configuration", rb_pf2_session_configuration, 0);
 }

--- a/ext/pf2c/session.h
+++ b/ext/pf2c/session.h
@@ -6,6 +6,7 @@
 
 #include <ruby.h>
 
+#include "configuration.h"
 #include "ringbuffer.h"
 #include "sample.h"
 
@@ -23,10 +24,14 @@ struct pf2_session {
     struct timespec start_time_realtime;
     struct timespec start_time; // When profiling started
     uint64_t duration_ns; // Duration of profiling in nanoseconds
+
+    struct pf2_configuration *configuration;
 };
 
+VALUE rb_pf2_session_initialize(int argc, VALUE *argv, VALUE self);
 VALUE rb_pf2_session_start(VALUE self);
 VALUE rb_pf2_session_stop(VALUE self);
+VALUE rb_pf2_session_configuration(VALUE self);
 VALUE pf2_session_alloc(VALUE self);
 void pf2_session_dmark(void *sess);
 void pf2_session_dfree(void *sess);


### PR DESCRIPTION
This patch adds configuration two configuration options to Pf2c::Session#initialize.

- interval_ms: The interval for sample collection
- time_mode: :cpu or :wall

The `scheduler` and `threads` option is not supported yet. `use_experimental_serializer` is also unsupported, as Pf2c always works in the experimental serializer (Ser2) mode.