### PR TITLE
Use setitimer() when timer_create() is unsupported

### DIFF
--- a/ext/pf2/extconf.rb
+++ b/ext/pf2/extconf.rb
@@ -15,7 +15,13 @@ append_ldflags('-lrt') # for timer_create
 append_cflags('-fvisibility=hidden')
 append_cflags('-DPF2_DEBUG') if ENV['PF2_DEBUG'] == '1'
 
-if have_func('timer_create')
+# Check for timer functions
+have_timer_create = have_func('timer_create')
+have_setitimer = have_func('setitimer')
+
+if have_timer_create || have_setitimer
   $srcs = Dir.glob("#{File.join(File.dirname(__FILE__), '*.c')}")
   create_makefile 'pf2/pf2'
+else
+  raise 'Neither timer_create nor setitimer is available'
 end

--- a/ext/pf2/session.h
+++ b/ext/pf2/session.h
@@ -3,6 +3,7 @@
 
 #include <pthread.h>
 #include <stdatomic.h>
+#include <sys/time.h>
 
 #include <ruby.h>
 
@@ -12,7 +13,11 @@
 
 struct pf2_session {
     bool is_running;
+#ifdef HAVE_TIMER_CREATE
     timer_t timer;
+#else
+    struct itimerval timer;
+#endif
     struct pf2_ringbuffer *rbuf;
     atomic_bool is_marking; // Whether garbage collection is in progress
     pthread_t *collector_thread;


### PR DESCRIPTION
Some platforms do not provide timer_create(). Fall back to setitimer() on such platforms.

setitimer() provides less control over the timer. The signal to be delivered cannot be controlled - ITIMER_PROF timers always causes SIGPROFs and ITIMER_REAL timers always causes SIGALRMs. This patch adds a SIGALRM handler as well.

Also, no opaque pointer (*data) cannot be passed to the signal handler. This is problemsome since the signal handler needs to access the pf2_session struct to write data. For now, the session pointer is stored in a global variable to workaround this limitation.