### PR TITLE
Declare logger gem as dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     pf2 (1.0.0.alpha1)
+      logger
       mini_portile2
       rake-compiler
       webrick
@@ -16,6 +17,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    logger (1.7.0)
     mini_portile2 (2.8.8)
     minitest (5.25.5)
     pp (0.6.2)

--- a/pf2.gemspec
+++ b/pf2.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'logger'
   spec.add_dependency 'rake-compiler'
   spec.add_dependency 'mini_portile2'
   spec.add_dependency 'webrick'


### PR DESCRIPTION
Ruby 3.5 no longer includes logger as a default gem.