### PR TITLE
Ensure profiling termination when Pf2::Session is GC'd

### DIFF
--- a/ext/pf2/session.h
+++ b/ext/pf2/session.h
@@ -50,7 +50,7 @@ static const rb_data_type_t pf2_session_type = {
         .dsize = pf2_session_dsize,
     },
     .data = NULL,
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+    .flags = 0,
 };
 
 #endif // PF2_SESSION_H


### PR DESCRIPTION
Profiling must be terminated (no signal handlers left) before fields in pf2_session gets freed.

This patch drops the RUBY_TYPED_FREE_IMMEDIATELY flag from pf2_session_type to prevent pf2_session to be free()'d before dfree().