### PR TITLE
Add Ruby 4.0 to test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-22.04', 'ubuntu-24.04']
-        ruby-version: ['3.3', '3.4']
+        ruby-version: ['3.3', '3.4', '4.0']
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/