### PR TITLE
Add test where program exits before Pf2.stop

### DIFF
--- a/test/script_completion_test.rb
+++ b/test/script_completion_test.rb
@@ -16,4 +16,8 @@ class ScriptCompletionTest < Minitest::Test
   def test_mandelbrot_in_multiple_threads_completes
     assert_equal(true, system_with_timeout('bundle exec ruby test/test_scripts/mandelbrot_in_multiple_threads.rb', 15).success?)
   end
+
+  def test_exit_while_profiling_completes
+    assert_equal(true, system_with_timeout('bundle exec ruby test/test_scripts/exit_while_profiling.rb', 3).success?)
+  end
 end

--- a/test/test_scripts/exit_while_profiling.rb
+++ b/test/test_scripts/exit_while_profiling.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'pf2'
+
+Pf2.start
+10000.times { 1 + 1 }
+# Exit without stopping the profiler


### PR DESCRIPTION
Adds the script in https://github.com/osyoyu/pf2/issues/56 as a test.
Looks like this was fixed somewhere.