### PR TITLE
StackWeaver: Handle functions prefixed with 'lto_priv'

### DIFF
--- a/lib/pf2/reporter/stack_weaver.rb
+++ b/lib/pf2/reporter/stack_weaver.rb
@@ -82,7 +82,7 @@ module Pf2
 
         # If the next function is a vm_exec_core() (= VM_EXEC in vm_exec.h),
         # we switch to the Ruby stack.
-        function[:name] == 'vm_exec_core'
+        function[:name]&.match?(/\Avm_exec_core(?:\.lto_priv\.\d+)?\z/)
       end
     end
   end


### PR DESCRIPTION
When the Ruby binary is compiled with LTO, vm_exec_core() may appear as vm_exec_core.lto_priv.0(). This patch lets StackWeaver detect such cases as well.

(Contributed by @hanazuki)