### PR TITLE
Fix misaligned sample capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 ### Fixed
 
-- Fixed an bug where the program would crash when a `Pf2::Session` is GC'd before profiling starts.
+- Fixed an bug where the program crashes when a `Pf2::Session` is GC'd before profiling starts.
+- Fixed an bug where the program crashes when the native stack was more than 200 frames deep.
 
 
 ## [0.10.0] - 2025-12-26

--- a/ext/pf2/sample.c
+++ b/ext/pf2/sample.c
@@ -9,8 +9,6 @@
 #include "backtrace_state.h"
 #include "sample.h"
 
-const int PF2_SAMPLE_MAX_NATIVE_DEPTH = 300;
-
 static int capture_native_backtrace(struct pf2_sample *sample);
 static int backtrace_on_ok(void *data, uintptr_t pc);
 
@@ -29,7 +27,7 @@ pf2_sample_capture(struct pf2_sample *sample)
     sample->context_pthread = pthread_self();
 
     // Obtain the current stack from Ruby
-    sample->depth = rb_profile_frames(0, 200, sample->cmes, sample->linenos);
+    sample->depth = rb_profile_frames(0, PF2_SAMPLE_MAX_RUBY_DEPTH, sample->cmes, sample->linenos);
 
     // Capture C-level backtrace
     sample->native_stack_depth = capture_native_backtrace(sample);

--- a/ext/pf2/sample.h
+++ b/ext/pf2/sample.h
@@ -5,17 +5,18 @@
 
 #include <ruby.h>
 
-extern const int PF2_SAMPLE_MAX_NATIVE_DEPTH;
+#define PF2_SAMPLE_MAX_RUBY_DEPTH 200
+#define PF2_SAMPLE_MAX_NATIVE_DEPTH 300
 
 struct pf2_sample {
     pthread_t context_pthread;
 
     int depth;
-    VALUE cmes[200];
-    int linenos[200];
+    VALUE cmes[PF2_SAMPLE_MAX_RUBY_DEPTH];
+    int linenos[PF2_SAMPLE_MAX_RUBY_DEPTH];
 
     size_t native_stack_depth;
-    uintptr_t native_stack[200];
+    uintptr_t native_stack[PF2_SAMPLE_MAX_NATIVE_DEPTH];
 
     uint64_t consumed_time_ns;
     uint64_t timestamp_ns;


### PR DESCRIPTION
While pf2_sample had capacity for native stacks up to 200 frames, the sampler tried to write up to 300 frames, causing crashes when the stack had more than 200 frames.