### PR TITLE
Make maximum stack depth to capture configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Pf2.start(
   interval_ms: 9,        # Integer: The sampling interval in milliseconds (default: 9)
   time_mode: :cpu,        # `:cpu` or `:wall`: The sampling timer's mode
                           # (default: `:cpu` for SignalScheduler, `:wall` for TimerThreadScheduler)
+  max_depth: 200,         # Integer: Maximum Ruby stack depth to capture (default: 200, max: 8192)
+  max_native_depth: 300,  # Integer: Maximum Native stack depth to capture (default: 300, max: 8192)
   threads: [th1, th2],    # `Array<Thread>` | `:all`: A list of Ruby Threads to be tracked.
                           # When `:all` or unspecified, Pf2 will track all active Threads.
 )

--- a/ext/pf2/configuration.c
+++ b/ext/pf2/configuration.c
@@ -5,6 +5,8 @@
 
 static int extract_interval_ms(VALUE options_hash);
 static enum pf2_time_mode extract_time_mode(VALUE options_hash);
+static int extract_max_ruby_depth(VALUE options_hash);
+static int extract_max_native_depth(VALUE options_hash);
 
 struct pf2_configuration *
 pf2_configuration_new_from_options_hash(VALUE options_hash)
@@ -16,6 +18,8 @@ pf2_configuration_new_from_options_hash(VALUE options_hash)
 
     config->interval_ms = extract_interval_ms(options_hash);
     config->time_mode = extract_time_mode(options_hash);
+    config->max_ruby_depth = extract_max_ruby_depth(options_hash);
+    config->max_native_depth = extract_max_native_depth(options_hash);
 
     return config;
 }
@@ -57,6 +61,52 @@ extract_time_mode(VALUE options_hash)
     }
 }
 
+static int
+extract_max_ruby_depth(VALUE options_hash)
+{
+    if (options_hash == Qnil) {
+        return PF2_DEFAULT_MAX_RUBY_DEPTH;
+    }
+
+    VALUE max_ruby_depth_value = rb_hash_aref(options_hash, ID2SYM(rb_intern("max_depth")));
+    if (max_ruby_depth_value == Qundef || max_ruby_depth_value == Qnil) {
+        return PF2_DEFAULT_MAX_RUBY_DEPTH;
+    }
+
+    int ruby_depth = NUM2INT(max_ruby_depth_value);
+    if (ruby_depth <= 0) {
+        rb_raise(rb_eArgError, "max_depth must be positive");
+    }
+    if (ruby_depth > PF2_MAX_RUBY_STACK_DEPTH) {
+        rb_raise(rb_eArgError, "max_depth must be <= %d", PF2_MAX_RUBY_STACK_DEPTH);
+    }
+
+    return ruby_depth;
+}
+
+static int
+extract_max_native_depth(VALUE options_hash)
+{
+    if (options_hash == Qnil) {
+        return PF2_DEFAULT_MAX_NATIVE_DEPTH;
+    }
+
+    VALUE max_native_depth = rb_hash_aref(options_hash, ID2SYM(rb_intern("max_native_depth")));
+    if (max_native_depth == Qundef || max_native_depth == Qnil) {
+        return PF2_DEFAULT_MAX_NATIVE_DEPTH;
+    }
+
+    int depth = NUM2INT(max_native_depth);
+    if (depth <= 0) {
+        rb_raise(rb_eArgError, "max_native_depth must be positive");
+    }
+    if (depth > PF2_MAX_NATIVE_STACK_DEPTH) {
+        rb_raise(rb_eArgError, "max_native_depth must be <= %d", PF2_MAX_NATIVE_STACK_DEPTH);
+    }
+
+    return depth;
+}
+
 void
 pf2_configuration_free(struct pf2_configuration *config)
 {
@@ -85,6 +135,12 @@ pf2_configuration_to_ruby_hash(struct pf2_configuration *config)
         break;
     }
     rb_hash_aset(hash, ID2SYM(rb_intern("time_mode")), time_mode_sym);
+
+    // max_depth
+    rb_hash_aset(hash, ID2SYM(rb_intern("max_depth")), INT2NUM(config->max_ruby_depth));
+
+    // max_native_depth
+    rb_hash_aset(hash, ID2SYM(rb_intern("max_native_depth")), INT2NUM(config->max_native_depth));
 
     return hash;
 }

--- a/ext/pf2/configuration.h
+++ b/ext/pf2/configuration.h
@@ -11,10 +11,16 @@ enum pf2_time_mode {
 struct pf2_configuration {
     int interval_ms;
     enum pf2_time_mode time_mode;
+    int max_ruby_depth;
+    int max_native_depth;
 };
 
 #define PF2_DEFAULT_INTERVAL_MS 9
 #define PF2_DEFAULT_TIME_MODE PF2_TIME_MODE_CPU_TIME
+#define PF2_DEFAULT_MAX_RUBY_DEPTH 200
+#define PF2_DEFAULT_MAX_NATIVE_DEPTH 300
+#define PF2_MAX_RUBY_STACK_DEPTH 8192
+#define PF2_MAX_NATIVE_STACK_DEPTH 8192
 
 struct pf2_configuration *pf2_configuration_new_from_options_hash(VALUE options_hash);
 void pf2_configuration_free(struct pf2_configuration *config);

--- a/ext/pf2/ringbuffer.c
+++ b/ext/pf2/ringbuffer.c
@@ -3,8 +3,10 @@
 
 #include "ringbuffer.h"
 
+static bool pf2_sample_init(struct pf2_sample *sample, int max_ruby_depth, int max_native_depth);
+
 struct pf2_ringbuffer *
-pf2_ringbuffer_new(int size) {
+pf2_ringbuffer_new(int size, int max_ruby_depth, int max_native_depth) {
     if (size <= 0) { return NULL; }
 
     struct pf2_ringbuffer *ringbuf = malloc(sizeof(struct pf2_ringbuffer));
@@ -12,8 +14,19 @@ pf2_ringbuffer_new(int size) {
     ringbuf->size = size + 1; // One extra slot is required to distinguish full from empty
     ringbuf->head = 0;
     ringbuf->tail = 0;
+
+    // Allocate space for samples to be stored
     ringbuf->samples = malloc(ringbuf->size * sizeof(struct pf2_sample));
     if (!ringbuf->samples) { goto err_free_ringbuf; }
+    for (int i = 0; i < ringbuf->size; i++) {
+        if (!pf2_sample_init(&ringbuf->samples[i], max_ruby_depth, max_native_depth)) {
+            for (int j = 0; j < i; j++) {
+                pf2_sample_free(&ringbuf->samples[j]);
+            }
+            free(ringbuf->samples);
+            goto err_free_ringbuf;
+        }
+    }
     return ringbuf;
 
 err_free_ringbuf:
@@ -22,33 +35,68 @@ err:
     return NULL;
 }
 
+static bool
+pf2_sample_init(struct pf2_sample *sample, int max_ruby_depth, int max_native_depth)
+{
+    sample->cmes = malloc(sizeof(VALUE) * max_ruby_depth);
+    sample->linenos = malloc(sizeof(int) * max_ruby_depth);
+    sample->native_stack = malloc(sizeof(uintptr_t) * max_native_depth);
+    if (sample->cmes == NULL || sample->linenos == NULL || sample->native_stack == NULL) {
+        free(sample->cmes);
+        free(sample->linenos);
+        free(sample->native_stack);
+        sample->cmes = NULL;
+        sample->linenos = NULL;
+        sample->native_stack = NULL;
+        return false;
+    }
+
+    sample->depth = 0;
+    sample->native_stack_depth = 0;
+    sample->consumed_time_ns = 0;
+    sample->timestamp_ns = 0;
+
+    return true;
+}
+
 void
 pf2_ringbuffer_free(struct pf2_ringbuffer *ringbuf) {
+    for (int i = 0; i < ringbuf->size; i++) {
+        pf2_sample_free(&ringbuf->samples[i]);
+    }
     free(ringbuf->samples);
     free(ringbuf);
 }
 
 // Returns 0 on success, 1 on failure (buffer full).
 bool
-pf2_ringbuffer_push(struct pf2_ringbuffer *ringbuf, struct pf2_sample *sample) {
+pf2_ringbuffer_reserve(struct pf2_ringbuffer *ringbuf, struct pf2_sample **sample, int *next_tail) {
     // Tail is only modified by the producer thread (us), so relaxed ordering is sufficient
     const int current_tail = atomic_load_explicit(&ringbuf->tail, memory_order_relaxed);
-    const int next_tail = (current_tail + 1) % ringbuf->size;
+    const int next_tail_local = (current_tail + 1) % ringbuf->size;
 
     // Check head to see if buffer is full. If next_tail == head, the buffer is full.
     // Use acquire ordering to synchronize with the head update in pf2_ringbuffer_pop().
     // This ensures we see the latest head value.
-    if (next_tail == atomic_load_explicit(&ringbuf->head, memory_order_acquire)) {
+    if (next_tail_local == atomic_load_explicit(&ringbuf->head, memory_order_acquire)) {
         return false;  // Buffer full
     }
 
-    // Copy the sample from the provided input pointer to the buffer.
-    ringbuf->samples[current_tail] = *sample;
+    // Expose the slot pointer without publishing it yet. The producer must fill this slot
+    // fully before calling commit; until then, the consumer will not see it because tail
+    // remains unchanged.
+    *sample = &ringbuf->samples[current_tail];
+    // Hand back the computed next tail so the producer can publish atomically after capture.
+    *next_tail = next_tail_local;
 
+    return true;
+}
+
+void
+pf2_ringbuffer_commit(struct pf2_ringbuffer *ringbuf, int next_tail) {
     // Use release ordering when updating tail to ensure the sample write is visible
     // to the consumer before they see the new tail value
     atomic_store_explicit(&ringbuf->tail, next_tail, memory_order_release);
-    return true;
 }
 
 // Returns 0 on success, 1 on failure (buffer empty).

--- a/ext/pf2/ringbuffer.h
+++ b/ext/pf2/ringbuffer.h
@@ -15,10 +15,12 @@ struct pf2_ringbuffer {
     struct pf2_sample *samples;
 };
 
-struct pf2_ringbuffer * pf2_ringbuffer_new(int size);
+struct pf2_ringbuffer * pf2_ringbuffer_new(int size, int max_ruby_depth, int max_native_depth);
 void pf2_ringbuffer_free(struct pf2_ringbuffer *ringbuf);
 // async-signal-safe
-bool pf2_ringbuffer_push(struct pf2_ringbuffer *ringbuf, struct pf2_sample *sample);
+bool pf2_ringbuffer_reserve(struct pf2_ringbuffer *ringbuf, struct pf2_sample **sample, int *next_tail);
+// async-signal-safe
+void pf2_ringbuffer_commit(struct pf2_ringbuffer *ringbuf, int next_tail);
 bool pf2_ringbuffer_pop(struct pf2_ringbuffer *ringbuf, struct pf2_sample *out);
 
 #endif // RINGBUFFER_H

--- a/ext/pf2/sample.h
+++ b/ext/pf2/sample.h
@@ -5,23 +5,23 @@
 
 #include <ruby.h>
 
-#define PF2_SAMPLE_MAX_RUBY_DEPTH 200
-#define PF2_SAMPLE_MAX_NATIVE_DEPTH 300
+#include "configuration.h"
 
 struct pf2_sample {
     pthread_t context_pthread;
 
     int depth;
-    VALUE cmes[PF2_SAMPLE_MAX_RUBY_DEPTH];
-    int linenos[PF2_SAMPLE_MAX_RUBY_DEPTH];
+    VALUE *cmes;
+    int *linenos;
 
     size_t native_stack_depth;
-    uintptr_t native_stack[PF2_SAMPLE_MAX_NATIVE_DEPTH];
+    uintptr_t *native_stack;
 
     uint64_t consumed_time_ns;
     uint64_t timestamp_ns;
 };
 
-bool pf2_sample_capture(struct pf2_sample *sample);
+void pf2_sample_free(struct pf2_sample *sample);
+bool pf2_sample_capture(struct pf2_sample *sample, const struct pf2_configuration *config);
 
 #endif // PF2_SAMPLE_H

--- a/test/depth_truncation_test.rb
+++ b/test/depth_truncation_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative './test_helper.rb'
+
+require 'pf2'
+
+def deep_call(level)
+  return 1000.times { 1 + 1 } if level <= 0
+  deep_call(level - 1)
+end
+
+class DepthTruncationTest < Minitest::Test
+  def test_stacks_are_truncated_to_configured_depths
+    profile = Pf2.profile(interval_ms: 1, max_depth: 5) do
+      deadline = Process.clock_gettime(Process::CLOCK_PROCESS_CPUTIME_ID) + 0.05
+      while Process.clock_gettime(Process::CLOCK_PROCESS_CPUTIME_ID) < deadline
+        deep_call(10)
+      end
+    end
+
+    assert_not_empty profile[:samples], "expected profiler to collect samples"
+
+    profile[:samples].each do |sample|
+      assert_operator sample[:stack].length, :<=, 5
+      assert_operator sample[:native_stack].length, :<=, 3
+    end
+  end
+end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -10,6 +10,8 @@ class SessionTest < Minitest::Test
 
     assert_equal(9, session.configuration[:interval_ms])
     assert_equal(:cpu, session.configuration[:time_mode])
+    assert_equal(200, session.configuration[:max_depth])
+    assert_equal(300, session.configuration[:max_native_depth])
   end
 
   def test_interval_ms_option
@@ -20,5 +22,23 @@ class SessionTest < Minitest::Test
   def test_time_mode_option
     session = Pf2::Session.new(time_mode: :wall)
     assert_equal(:wall, session.configuration[:time_mode])
+  end
+
+  def test_depth_options
+    session = Pf2::Session.new(max_depth: 700, max_native_depth: 123)
+    assert_equal(700, session.configuration[:max_depth])
+    assert_equal(123, session.configuration[:max_native_depth])
+  end
+
+  def test_depth_options_must_be_positive
+    Pf2::Session.new(max_depth: 1, max_native_depth: 1)
+    assert_raises(ArgumentError) { Pf2::Session.new(max_depth: 0) }
+    assert_raises(ArgumentError) { Pf2::Session.new(max_native_depth: 0) }
+  end
+
+  def test_depth_options_must_not_exceed_limit
+    Pf2::Session.new(max_depth: 8192, max_native_depth: 8192)
+    assert_raises(ArgumentError) { Pf2::Session.new(max_depth: 8193) }
+    assert_raises(ArgumentError) { Pf2::Session.new(max_native_depth: 8193) }
   end
 end


### PR DESCRIPTION
Pf2 had a hard-coded limit of 200 Ruby frames and 300 native frames, which was a conservative value chosen to keep memory consumption low. That was a too low limit for some applications, including large views in Rails applications.

This patch makes max_depth and max_native_depth configurable, allowing stack size up to 8192 frames. There is no particular reason for 8192, it just seemed to be a large enough number.