### PR TITLE
Increase max stack depth to 1024 (Ruby), 512 (Native)

### DIFF
--- a/ext/pf2/sample.h
+++ b/ext/pf2/sample.h
@@ -5,8 +5,8 @@
 
 #include <ruby.h>
 
-#define PF2_SAMPLE_MAX_RUBY_DEPTH 200
-#define PF2_SAMPLE_MAX_NATIVE_DEPTH 300
+#define PF2_SAMPLE_MAX_RUBY_DEPTH 1024
+#define PF2_SAMPLE_MAX_NATIVE_DEPTH 512
 
 struct pf2_sample {
     pthread_t context_pthread;


### PR DESCRIPTION
Related: https://github.com/osyoyu/pf2/pull/71

Sometimes, larger Rails apps have deep stacks, especially in views. This patch expands the max stack depth to 1024 from 200 for Ruby, and 512 from 300 for Native stacks. While native stacks have a rather shallow stack in CRuby, Ruby frames can go wild.