### PR TITLE
Allow manual SIGPROF sending for testing

### DIFF
--- a/ext/pf2/configuration.c
+++ b/ext/pf2/configuration.c
@@ -1,10 +1,12 @@
 #include <ruby.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include "configuration.h"
 
 static int extract_interval_ms(VALUE options_hash);
 static enum pf2_time_mode extract_time_mode(VALUE options_hash);
+static bool extract__test_no_install_timer(VALUE options_hash);
 
 struct pf2_configuration *
 pf2_configuration_new_from_options_hash(VALUE options_hash)
@@ -16,6 +18,7 @@ pf2_configuration_new_from_options_hash(VALUE options_hash)
 
     config->interval_ms = extract_interval_ms(options_hash);
     config->time_mode = extract_time_mode(options_hash);
+    config->_test_no_install_timer = extract__test_no_install_timer(options_hash);
 
     return config;
 }
@@ -55,6 +58,17 @@ extract_time_mode(VALUE options_hash)
         VALUE time_mode_str = rb_obj_as_string(time_mode);
         rb_raise(rb_eArgError, "Invalid time mode: %s", StringValueCStr(time_mode_str));
     }
+}
+
+static bool
+extract__test_no_install_timer(VALUE options_hash)
+{
+    if (options_hash == Qnil) {
+        return PF2_DEFAULT__TEST_NO_INSTALL_TIMER;
+    }
+
+    VALUE _test_no_install_timer = rb_hash_aref(options_hash, ID2SYM(rb_intern("_test_no_install_timer")));
+    return RTEST(_test_no_install_timer);
 }
 
 void

--- a/ext/pf2/configuration.h
+++ b/ext/pf2/configuration.h
@@ -2,6 +2,7 @@
 #define PF2_CONFIGURATION_H
 
 #include <ruby.h>
+#include <stdbool.h>
 
 enum pf2_time_mode {
     PF2_TIME_MODE_CPU_TIME,
@@ -11,10 +12,12 @@ enum pf2_time_mode {
 struct pf2_configuration {
     int interval_ms;
     enum pf2_time_mode time_mode;
+    bool _test_no_install_timer; // for testing only
 };
 
 #define PF2_DEFAULT_INTERVAL_MS 9
 #define PF2_DEFAULT_TIME_MODE PF2_TIME_MODE_CPU_TIME
+#define PF2_DEFAULT__TEST_NO_INSTALL_TIMER false
 
 struct pf2_configuration *pf2_configuration_new_from_options_hash(VALUE options_hash);
 void pf2_configuration_free(struct pf2_configuration *config);


### PR DESCRIPTION
Always store the session object in a global variable, eliminating the need for sival_ptr.

I want to make tests quicker and stable by allowing sampling to be triggered through `Process.kill`. However, sival_ptr needed to be populated with a pointer to the current session. While this is possible through sigqueue() on Linux, it is not portable across POSIX. Global variables is a good enough location to store global pointers.

This patch also adds a new option: '_test_no_install_timer` for disabling installation of kernel timers.