### PR TITLE
Fix pf2 serve

### DIFF
--- a/lib/pf2/serve.rb
+++ b/lib/pf2/serve.rb
@@ -27,10 +27,9 @@ module Pf2
       server = WEBrick::HTTPServer.new(CONFIG)
       server.mount_proc('/profile') do |req, res|
         profile = Pf2.stop
-        profile = JSON.parse(profile, symbolize_names: true, max_nesting: false)
         res.header['Content-Type'] = 'application/json'
         res.header['Access-Control-Allow-Origin'] = '*'
-        res.body = JSON.generate(Pf2::Reporter::FirefoxProfiler.new((profile)).emit)
+        res.body = JSON.generate(Pf2::Reporter::FirefoxProfilerSer2.new(profile).emit)
         Pf2.start
       end
 


### PR DESCRIPTION
`pf2 serve` broke when FirefoxProfiler was removed.